### PR TITLE
Add simplified test case for 462 that triggers it without any interaction

### DIFF
--- a/issues/462/462-active-group-is-lathe-triggered-double-free.slvs
+++ b/issues/462/462-active-group-is-lathe-triggered-double-free.slvs
@@ -1,0 +1,6461 @@
+±²³SolveSpaceREVa
+
+
+Group.h.v=00000001
+Group.type=5000
+Group.name=#references
+Group.color=ff000000
+Group.skipFirst=0
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000002
+Group.type=5001
+Group.order=1
+Group.name=screwdriver measurements width
+Group.activeWorkplane.v=80020000
+Group.color=ff000000
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=1.00000000000000000000
+Group.predef.origin.v=00010001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000003
+Group.type=5001
+Group.order=2
+Group.name=design measurements length
+Group.activeWorkplane.v=80030000
+Group.color=00646464
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=0.70710678118654757274
+Group.predef.q.vy=0.70710678118654746172
+Group.predef.origin.v=00080001
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000004
+Group.type=5001
+Group.order=3
+Group.name=profile
+Group.activeWorkplane.v=80040000
+Group.color=00646464
+Group.subtype=6000
+Group.skipFirst=0
+Group.predef.q.w=0.50000000000000000000
+Group.predef.q.vx=-0.50000000000000000000
+Group.predef.q.vy=0.50000000000000000000
+Group.predef.q.vz=-0.50000000000000000000
+Group.predef.origin.v=00120002
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+}
+AddGroup
+
+Group.h.v=00000005
+Group.type=5101
+Group.order=4
+Group.name=lathe
+Group.opA.v=00000004
+Group.color=00646464
+Group.skipFirst=0
+Group.predef.origin.v=80030002
+Group.predef.entityB.v=000c0000
+Group.predef.swapUV=0
+Group.predef.negateU=0
+Group.predef.negateV=0
+Group.visible=1
+Group.suppress=0
+Group.relaxConstraints=0
+Group.allowRedundant=0
+Group.allDimsReference=0
+Group.scale=1.00000000000000000000
+Group.remap={
+    1 80030002 1
+    2 00150000 1006
+    3 00150001 1006
+    4 00150002 1006
+    5 00150000 1007
+    6 00150001 1007
+    7 00150002 1007
+    8 80030002 2
+    9 00150001 1008
+    10 00150001 1009
+    11 80030002 3
+    12 00150002 1008
+    13 00150002 1009
+    14 80030002 4
+    15 00160000 1006
+    16 00160001 1006
+    17 00160002 1006
+    18 00160000 1007
+    19 00160001 1007
+    20 00160002 1007
+    21 80030002 5
+    22 00160001 1008
+    23 00160001 1009
+    24 80030002 6
+    25 00160002 1008
+    26 00160002 1009
+    27 80030002 7
+    28 00170000 1006
+    29 00170001 1006
+    30 00170002 1006
+    31 00170000 1007
+    32 00170001 1007
+    33 00170002 1007
+    34 80030002 8
+    35 00170001 1008
+    36 00170001 1009
+    37 80030002 9
+    38 00170002 1008
+    39 00170002 1009
+    40 80030002 10
+    41 00180000 1006
+    42 00180001 1006
+    43 00180002 1006
+    44 00180000 1007
+    45 00180001 1007
+    46 00180002 1007
+    47 80030002 11
+    48 00180001 1008
+    49 00180001 1009
+    50 80030002 12
+    51 00180002 1008
+    52 00180002 1009
+    53 80030002 13
+    54 00190000 1006
+    55 00190001 1006
+    56 00190002 1006
+    57 00190000 1007
+    58 00190001 1007
+    59 00190002 1007
+    60 80030002 14
+    61 00190001 1008
+    62 00190001 1009
+    63 80030002 15
+    64 00190002 1008
+    65 00190002 1009
+    66 80030002 16
+    67 001c0000 1006
+    68 001c0001 1006
+    69 001c0002 1006
+    70 001c0000 1007
+    71 001c0001 1007
+    72 001c0002 1007
+    73 80030002 17
+    74 001c0001 1008
+    75 001c0001 1009
+    76 80030002 18
+    77 001c0002 1008
+    78 001c0002 1009
+    79 80030002 19
+    80 001d0000 1006
+    81 001d0001 1006
+    82 001d0002 1006
+    83 001d0000 1007
+    84 001d0001 1007
+    85 001d0002 1007
+    86 001d0000 1004
+    87 80030002 20
+    88 001d0001 1008
+    89 001d0001 1009
+    90 80030002 21
+    91 001d0002 1008
+    92 001d0002 1009
+    93 80030002 22
+    94 001e0000 1006
+    95 001e0001 1006
+    96 001e0002 1006
+    97 001e0000 1007
+    98 001e0001 1007
+    99 001e0002 1007
+    100 80030002 23
+    101 001e0001 1008
+    102 001e0001 1009
+    103 80030002 24
+    104 001e0002 1008
+    105 001e0002 1009
+    106 80030002 25
+    107 001f0000 1006
+    108 001f0001 1006
+    109 001f0002 1006
+    110 001f0000 1007
+    111 001f0001 1007
+    112 001f0002 1007
+    113 80030002 26
+    114 001f0001 1008
+    115 001f0001 1009
+    116 80030002 27
+    117 001f0002 1008
+    118 001f0002 1009
+    119 80030002 28
+    120 00200000 1006
+    121 00200001 1006
+    122 00200002 1006
+    123 00200000 1007
+    124 00200001 1007
+    125 00200002 1007
+    126 80030002 29
+    127 00200001 1008
+    128 00200001 1009
+    129 80030002 30
+    130 00200002 1008
+    131 00200002 1009
+    132 80030002 31
+    133 00210000 1006
+    134 00210001 1006
+    135 00210002 1006
+    136 00210000 1007
+    137 00210001 1007
+    138 00210002 1007
+    139 80030002 32
+    140 00210001 1008
+    141 00210001 1009
+    142 80030002 33
+    143 00210002 1008
+    144 00210002 1009
+    145 80030002 34
+    146 00220000 1006
+    147 00220001 1006
+    148 00220002 1006
+    149 00220000 1007
+    150 00220001 1007
+    151 00220002 1007
+    152 00220000 1004
+    153 80030002 35
+    154 00220001 1008
+    155 00220001 1009
+    156 80030002 36
+    157 00220002 1008
+    158 00220002 1009
+    159 80030002 37
+    160 00230000 1006
+    161 00230001 1006
+    162 00230002 1006
+    163 00230000 1007
+    164 00230001 1007
+    165 00230002 1007
+    166 00230000 1004
+    167 80030002 38
+    168 00230001 1008
+    169 00230001 1009
+    170 80030002 39
+    171 00230002 1008
+    172 00230002 1009
+    173 80030002 40
+    174 80040000 1006
+    175 80040000 1007
+    176 80030002 41
+    177 80040001 1006
+    178 80040002 1006
+    179 80040001 1007
+    180 80040002 1007
+    181 80030002 42
+    182 80040002 1008
+    183 80040002 1009
+    184 00180000 1004
+    185 00190000 1004
+    186 001e0000 1004
+    187 001f0000 1004
+    188 00200000 1004
+    189 00210000 1004
+    190 001c0000 1004
+    191 00170000 1004
+    192 00160000 1004
+    193 00150000 1004
+    194 00270000 1006
+    195 00270001 1006
+    196 00270002 1006
+    197 00270000 1007
+    198 00270001 1007
+    199 00270002 1007
+    200 00270001 1008
+    201 00270001 1009
+    202 00270002 1008
+    203 00270002 1009
+    204 00280000 1006
+    205 00280001 1006
+    206 00280002 1006
+    207 00280000 1007
+    208 00280001 1007
+    209 00280002 1007
+    210 00280001 1008
+    211 00280001 1009
+    212 00280002 1008
+    213 00280002 1009
+    214 00280000 1004
+    215 00270000 1004
+}
+AddGroup
+
+Param.h.v.=00010010
+AddParam
+
+Param.h.v.=00010011
+AddParam
+
+Param.h.v.=00010012
+AddParam
+
+Param.h.v.=00010020
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00010021
+AddParam
+
+Param.h.v.=00010022
+AddParam
+
+Param.h.v.=00010023
+AddParam
+
+Param.h.v.=00020010
+AddParam
+
+Param.h.v.=00020011
+AddParam
+
+Param.h.v.=00020012
+AddParam
+
+Param.h.v.=00020020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020021
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020022
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00020023
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030010
+AddParam
+
+Param.h.v.=00030011
+AddParam
+
+Param.h.v.=00030012
+AddParam
+
+Param.h.v.=00030020
+Param.val=0.50000000000000000000
+AddParam
+
+Param.h.v.=00030021
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030022
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00030023
+Param.val=-0.50000000000000000000
+AddParam
+
+Param.h.v.=00080010
+AddParam
+
+Param.h.v.=00080011
+AddParam
+
+Param.h.v.=00080040
+Param.val=2.52499999999999991118
+AddParam
+
+Param.h.v.=00090010
+AddParam
+
+Param.h.v.=00090011
+Param.val=3.10000000000000008882
+AddParam
+
+Param.h.v.=00090013
+AddParam
+
+Param.h.v.=00090014
+Param.val=-3.10000000000000008882
+AddParam
+
+Param.h.v.=000a0010
+Param.val=-2.52499999999999991118
+AddParam
+
+Param.h.v.=000a0011
+AddParam
+
+Param.h.v.=000b0010
+Param.val=2.52499999999999991118
+AddParam
+
+Param.h.v.=000b0011
+AddParam
+
+Param.h.v.=000c0010
+AddParam
+
+Param.h.v.=000c0011
+AddParam
+
+Param.h.v.=000c0013
+Param.val=16.00000000000000000000
+AddParam
+
+Param.h.v.=000c0014
+AddParam
+
+Param.h.v.=000f0010
+AddParam
+
+Param.h.v.=000f0011
+Param.val=2.70000000000000017764
+AddParam
+
+Param.h.v.=000f0013
+AddParam
+
+Param.h.v.=000f0014
+Param.val=-2.70000000000000017764
+AddParam
+
+Param.h.v.=00100010
+Param.val=16.00000000000000000000
+AddParam
+
+Param.h.v.=00100011
+AddParam
+
+Param.h.v.=00100013
+Param.val=27.00000000000000000000
+AddParam
+
+Param.h.v.=00100014
+AddParam
+
+Param.h.v.=00110010
+Param.val=27.00000000000000000000
+AddParam
+
+Param.h.v.=00110011
+AddParam
+
+Param.h.v.=00110013
+Param.val=47.00000000000000000000
+AddParam
+
+Param.h.v.=00110014
+AddParam
+
+Param.h.v.=00120010
+AddParam
+
+Param.h.v.=00120011
+AddParam
+
+Param.h.v.=00120013
+Param.val=-1.00000000000000000000
+AddParam
+
+Param.h.v.=00120014
+AddParam
+
+Param.h.v.=00130010
+AddParam
+
+Param.h.v.=00130011
+Param.val=2.52499999999999991118
+AddParam
+
+Param.h.v.=00140010
+AddParam
+
+Param.h.v.=00140011
+Param.val=-2.52499999999999991118
+AddParam
+
+Param.h.v.=00150010
+Param.val=-2.70000000000000017764
+AddParam
+
+Param.h.v.=00150011
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00150013
+Param.val=-2.70000000000000017764
+AddParam
+
+Param.h.v.=00150014
+AddParam
+
+Param.h.v.=00160010
+Param.val=-2.70000000000000017764
+AddParam
+
+Param.h.v.=00160011
+AddParam
+
+Param.h.v.=00160013
+Param.val=-4.20000000000000017764
+AddParam
+
+Param.h.v.=00160014
+AddParam
+
+Param.h.v.=00180010
+Param.val=-2.70000000000000017764
+AddParam
+
+Param.h.v.=00180011
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00180013
+Param.val=-3.10000000000000008882
+AddParam
+
+Param.h.v.=00180014
+Param.val=17.00000000000000000000
+AddParam
+
+Param.h.v.=00190010
+Param.val=-3.10000000000000008882
+AddParam
+
+Param.h.v.=00190011
+Param.val=17.00000000000000000000
+AddParam
+
+Param.h.v.=00190013
+Param.val=-3.10000000000000008882
+AddParam
+
+Param.h.v.=00190014
+Param.val=48.00000000000000000000
+AddParam
+
+Param.h.v.=001d0010
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=001d0011
+Param.val=48.00000000000000000000
+AddParam
+
+Param.h.v.=001d0013
+Param.val=-3.10000000000000008882
+AddParam
+
+Param.h.v.=001d0014
+Param.val=48.00000000000000000000
+AddParam
+
+Param.h.v.=001e0010
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=001e0011
+Param.val=48.00000000000000000000
+AddParam
+
+Param.h.v.=001e0013
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=001e0014
+Param.val=45.00000000000000000000
+AddParam
+
+Param.h.v.=001f0010
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=001f0011
+Param.val=45.00000000000000000000
+AddParam
+
+Param.h.v.=001f0013
+Param.val=-3.85000000000000008882
+AddParam
+
+Param.h.v.=001f0014
+Param.val=44.25000000000000000000
+AddParam
+
+Param.h.v.=00200010
+Param.val=-3.85000000000000008882
+AddParam
+
+Param.h.v.=00200011
+Param.val=44.25000000000000000000
+AddParam
+
+Param.h.v.=00200013
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=00200014
+Param.val=43.50000000000000000000
+AddParam
+
+Param.h.v.=00210010
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=00210011
+Param.val=43.50000000000000000000
+AddParam
+
+Param.h.v.=00210013
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=00210014
+Param.val=17.00000000000000000000
+AddParam
+
+Param.h.v.=00220010
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=00220011
+Param.val=44.25000000000000000000
+AddParam
+
+Param.h.v.=00220013
+Param.val=-3.85000000000000008882
+AddParam
+
+Param.h.v.=00220014
+Param.val=44.25000000000000000000
+AddParam
+
+Param.h.v.=00230010
+Param.val=-3.85000000000000008882
+AddParam
+
+Param.h.v.=00230011
+Param.val=44.25000000000000000000
+AddParam
+
+Param.h.v.=00230013
+Param.val=-3.10000000000000008882
+AddParam
+
+Param.h.v.=00230014
+Param.val=44.25000000000000000000
+AddParam
+
+Param.h.v.=00240010
+Param.val=44.00000000000000000000
+AddParam
+
+Param.h.v.=00240011
+AddParam
+
+Param.h.v.=00250010
+AddParam
+
+Param.h.v.=00250011
+AddParam
+
+Param.h.v.=00250040
+Param.val=4.20000000000000017764
+AddParam
+
+Param.h.v.=00260010
+AddParam
+
+Param.h.v.=00260011
+Param.val=4.20000000000000017764
+AddParam
+
+Param.h.v.=00270010
+Param.val=-4.20000000000000017764
+AddParam
+
+Param.h.v.=00270011
+AddParam
+
+Param.h.v.=00270013
+Param.val=-4.20000000000000017764
+AddParam
+
+Param.h.v.=00270014
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00280010
+Param.val=-4.20000000000000017764
+AddParam
+
+Param.h.v.=00280011
+Param.val=1.00000000000000000000
+AddParam
+
+Param.h.v.=00280013
+Param.val=-4.59999999999999964473
+AddParam
+
+Param.h.v.=00280014
+Param.val=17.00000000000000000000
+AddParam
+
+Param.h.v.=00390010
+AddParam
+
+Param.h.v.=00390011
+AddParam
+
+Param.h.v.=00390040
+Param.val=2.37500000000000000000
+AddParam
+
+Param.h.v.=003a0010
+Param.val=2.37500000000000000000
+AddParam
+
+Param.h.v.=003a0011
+AddParam
+
+Param.h.v.=40000032
+Param.val=0.90725806451612900361
+AddParam
+
+Param.h.v.=40000033
+Param.val=0.09274193548387099639
+AddParam
+
+Param.h.v.=40000054
+Param.val=-0.05660377358490567556
+AddParam
+
+Param.h.v.=4000005b
+Param.val=0.87903225806451601443
+AddParam
+
+Param.h.v.=4000005e
+Param.val=0.84999999999999997780
+AddParam
+
+Param.h.v.=40000067
+Param.val=-0.17741935483870976964
+AddParam
+
+Request.h.v=00000001
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000002
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000003
+Request.type=100
+Request.group.v=00000001
+Request.construction=0
+AddRequest
+
+Request.h.v=00000008
+Request.type=400
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000009
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=1
+AddRequest
+
+Request.h.v=0000000a
+Request.type=101
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000b
+Request.type=101
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=0000000c
+Request.type=200
+Request.workplane.v=80030000
+Request.group.v=00000003
+Request.construction=1
+AddRequest
+
+Request.h.v=0000000f
+Request.type=200
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=1
+AddRequest
+
+Request.h.v=00000010
+Request.type=200
+Request.workplane.v=80030000
+Request.group.v=00000003
+Request.construction=1
+AddRequest
+
+Request.h.v=00000011
+Request.type=200
+Request.workplane.v=80030000
+Request.group.v=00000003
+Request.construction=1
+AddRequest
+
+Request.h.v=00000012
+Request.type=200
+Request.workplane.v=80030000
+Request.group.v=00000003
+Request.construction=1
+AddRequest
+
+Request.h.v=00000013
+Request.type=101
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000014
+Request.type=101
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000015
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000016
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000018
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000019
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000001d
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000001e
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=0000001f
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000020
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000021
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000022
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=1
+AddRequest
+
+Request.h.v=00000023
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=1
+AddRequest
+
+Request.h.v=00000024
+Request.type=101
+Request.workplane.v=80030000
+Request.group.v=00000003
+Request.construction=0
+AddRequest
+
+Request.h.v=00000025
+Request.type=400
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=1
+AddRequest
+
+Request.h.v=00000026
+Request.type=101
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=00000027
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000028
+Request.type=200
+Request.workplane.v=80040000
+Request.group.v=00000004
+Request.construction=0
+AddRequest
+
+Request.h.v=00000039
+Request.type=400
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Request.h.v=0000003a
+Request.type=101
+Request.workplane.v=80020000
+Request.group.v=00000002
+Request.construction=0
+AddRequest
+
+Entity.h.v=00010000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.normal.v=00010020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00010020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00010001
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.normal.v=00020020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00020020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00020001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.normal.v=00030020
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030001
+Entity.type=2000
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00030020
+Entity.type=3000
+Entity.construction=0
+Entity.point[0].v=00030001
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=-0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080000
+Entity.type=13000
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.normal.v=00080020
+Entity.distance.v=00080040
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080020
+Entity.type=3001
+Entity.construction=0
+Entity.point[0].v=00080001
+Entity.workplane.v=80020000
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00080040
+Entity.type=4000
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actDistance=2.52499999999999991118
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=00090001
+Entity.point[1].v=00090002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80020000
+Entity.actPoint.y=3.10000000000000008882
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00090002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80020000
+Entity.actPoint.y=-3.10000000000000008882
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000a0000
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=-2.52499999999999991118
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000b0000
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=2.52499999999999991118
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=000c0001
+Entity.point[1].v=000c0002
+Entity.workplane.v=80030000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000c0002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actPoint.x=0.00000000000000355271
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000f0000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=000f0001
+Entity.point[1].v=000f0002
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000f0001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80020000
+Entity.actPoint.y=2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=000f0002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80020000
+Entity.actPoint.y=-2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00100000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=00100001
+Entity.point[1].v=00100002
+Entity.workplane.v=80030000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00100001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actPoint.x=0.00000000000000355271
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00100002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actPoint.x=0.00000000000000599520
+Entity.actPoint.z=-27.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00110000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=00110001
+Entity.point[1].v=00110002
+Entity.workplane.v=80030000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00110001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actPoint.x=0.00000000000000599520
+Entity.actPoint.z=-27.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00110002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actPoint.x=0.00000000000001043610
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00120000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=00120001
+Entity.point[1].v=00120002
+Entity.workplane.v=80030000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00120001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00120002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80030000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00130000
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=2.52499999999999991118
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00140000
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=-2.52499999999999991118
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00150000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00150001
+Entity.point[1].v=00150002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00150001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00150002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00160000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00160001
+Entity.point[1].v=00160002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00160001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00160002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00180000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00180001
+Entity.point[1].v=00180002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00180001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00180002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00190000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00190001
+Entity.point[1].v=00190002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00190001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00190002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001d0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=001d0001
+Entity.point[1].v=001d0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001d0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001d0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001e0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=001e0001
+Entity.point[1].v=001e0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001e0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001e0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001f0000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=001f0001
+Entity.point[1].v=001f0002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001f0001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=001f0002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00200000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00200001
+Entity.point[1].v=00200002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00200001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00200002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00210000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00210001
+Entity.point[1].v=00210002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00210001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00210002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00220000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=00220001
+Entity.point[1].v=00220002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00220001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00220002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00230000
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=00230001
+Entity.point[1].v=00230002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00230001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00230002
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00240000
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80030000
+Entity.actPoint.x=0.00000000000000976996
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00250000
+Entity.type=13000
+Entity.construction=1
+Entity.point[0].v=00250001
+Entity.normal.v=00250020
+Entity.distance.v=00250040
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00250001
+Entity.type=2001
+Entity.construction=1
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00250020
+Entity.type=3001
+Entity.construction=1
+Entity.point[0].v=00250001
+Entity.workplane.v=80020000
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00250040
+Entity.type=4000
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actDistance=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00260000
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.y=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00270000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00270001
+Entity.point[1].v=00270002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00270001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00270002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00280000
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=00280001
+Entity.point[1].v=00280002
+Entity.workplane.v=80040000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00280001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00280002
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80040000
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00390000
+Entity.type=13000
+Entity.construction=0
+Entity.point[0].v=00390001
+Entity.normal.v=00390020
+Entity.distance.v=00390040
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00390001
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00390020
+Entity.type=3001
+Entity.construction=0
+Entity.point[0].v=00390001
+Entity.workplane.v=80020000
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=00390040
+Entity.type=4000
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actDistance=2.37500000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=003a0000
+Entity.type=2001
+Entity.construction=0
+Entity.workplane.v=80020000
+Entity.actPoint.x=2.37500000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.normal.v=80020001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80020001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80020002
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80020002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.normal.v=80030001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80030001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80030002
+Entity.actNormal.w=0.70710678118654757274
+Entity.actNormal.vy=0.70710678118654746172
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80030002
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040000
+Entity.type=10000
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.normal.v=80040001
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80040001
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80040002
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80040002
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050001
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050002
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050003
+Entity.point[1].v=80050004
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050003
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050004
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050005
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050006
+Entity.point[1].v=80050007
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050006
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050007
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050008
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.z=0.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050009
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050008
+Entity.point[1].v=80050003
+Entity.point[2].v=80050006
+Entity.normal.v=8005000a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000a
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050008
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=-0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000004112
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000b
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005000c
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.point[1].v=80050004
+Entity.point[2].v=80050007
+Entity.normal.v=8005000d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000d
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005000b
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005000e
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005000f
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050010
+Entity.point[1].v=80050011
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050010
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050011
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050012
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050013
+Entity.point[1].v=80050014
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050013
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050014
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050015
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050016
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050015
+Entity.point[1].v=80050010
+Entity.point[2].v=80050013
+Entity.normal.v=80050017
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050017
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050015
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050018
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050019
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050018
+Entity.point[1].v=80050011
+Entity.point[2].v=80050014
+Entity.normal.v=8005001a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001a
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050018
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005001b
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050022
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.z=0.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050025
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000355271
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050028
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050029
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005002a
+Entity.point[1].v=8005002b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005002a
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005002b
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005002c
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005002d
+Entity.point[1].v=8005002e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005002d
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005002e
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005002f
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000355271
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050030
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050022
+Entity.point[1].v=8005002a
+Entity.point[2].v=8005002d
+Entity.normal.v=80050031
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050031
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050022
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=-0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000004112
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050032
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000001043610
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050033
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050025
+Entity.point[1].v=8005002b
+Entity.point[2].v=8005002e
+Entity.normal.v=80050034
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050034
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050025
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000060883
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050035
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050036
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050037
+Entity.point[1].v=80050038
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050037
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050038
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050039
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005003a
+Entity.point[1].v=8005003b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005003a
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005003b
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005003c
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000001043610
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005003d
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=8005002f
+Entity.point[1].v=80050037
+Entity.point[2].v=8005003a
+Entity.normal.v=8005003e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005003e
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005002f
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000060883
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005003f
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000001043610
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050040
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050032
+Entity.point[1].v=80050038
+Entity.point[2].v=8005003b
+Entity.normal.v=80050041
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050041
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050032
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000171906
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050042
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050049
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000001043610
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005004c
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000976996
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005004f
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050050
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050051
+Entity.point[1].v=80050052
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050051
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050052
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050053
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050054
+Entity.point[1].v=80050055
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050054
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050055
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050056
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=001d0001
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actNormal.vx=-0.00000000000000022204
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050057
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000976996
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050058
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=8005003c
+Entity.point[1].v=80050051
+Entity.point[2].v=80050054
+Entity.normal.v=80050059
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050059
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005003c
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000115849
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005005a
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000960343
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005005b
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=8005003f
+Entity.point[1].v=80050052
+Entity.point[2].v=80050055
+Entity.normal.v=8005005c
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005005c
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005003f
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000171906
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005005d
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005005e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005005f
+Entity.point[1].v=80050060
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005005f
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050060
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050061
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050062
+Entity.point[1].v=80050063
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050062
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-47.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050063
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050064
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000960343
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050065
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050049
+Entity.point[1].v=8005005f
+Entity.point[2].v=80050062
+Entity.normal.v=80050066
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050066
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050049
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000115849
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050067
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000943690
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050068
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=8005004c
+Entity.point[1].v=80050060
+Entity.point[2].v=80050063
+Entity.normal.v=80050069
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050069
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005004c
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000108609
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005006a
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005006b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005006c
+Entity.point[1].v=8005006d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005006c
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005006d
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005006e
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005006f
+Entity.point[1].v=80050070
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005006f
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-44.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050070
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050071
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000943690
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050072
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050057
+Entity.point[1].v=8005006c
+Entity.point[2].v=8005006f
+Entity.normal.v=80050073
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050073
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050057
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000108609
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050074
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000355271
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050075
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=8005005a
+Entity.point[1].v=8005006d
+Entity.point[2].v=80050070
+Entity.normal.v=80050076
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050076
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005005a
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000127604
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050077
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050078
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050079
+Entity.point[1].v=8005007a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050079
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005007a
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005007b
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=8005007c
+Entity.point[1].v=8005007d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005007c
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005007d
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005007e
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000960343
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005007f
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050064
+Entity.point[1].v=80050079
+Entity.point[2].v=8005007c
+Entity.normal.v=80050080
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050080
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050064
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000127604
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050081
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000960343
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050082
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050067
+Entity.point[1].v=8005007a
+Entity.point[2].v=8005007d
+Entity.normal.v=80050083
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050083
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050067
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000104988
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050084
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050085
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050086
+Entity.point[1].v=80050087
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050086
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050087
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050088
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=80050089
+Entity.point[1].v=8005008a
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050089
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-42.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005008a
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005008b
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000960343
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005008c
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050071
+Entity.point[1].v=80050086
+Entity.point[2].v=80050089
+Entity.normal.v=8005008d
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005008d
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050071
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000104988
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005008e
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000960343
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005008f
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050074
+Entity.point[1].v=80050087
+Entity.point[2].v=8005008a
+Entity.normal.v=80050090
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050090
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050074
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000041030
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050091
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=80050092
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050093
+Entity.point[1].v=80050094
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050093
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050094
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050095
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=80050096
+Entity.point[1].v=80050097
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050096
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050097
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050098
+Entity.type=5000
+Entity.construction=1
+Entity.point[0].v=00220001
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actNormal.vx=-0.00000000000000022204
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=80050099
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005009a
+Entity.type=14000
+Entity.construction=1
+Entity.point[0].v=8005007e
+Entity.point[1].v=80050093
+Entity.point[2].v=80050096
+Entity.normal.v=8005009b
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005009b
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005007e
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000106799
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005009c
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.z=0.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=8005009d
+Entity.type=14000
+Entity.construction=1
+Entity.point[0].v=80050081
+Entity.point[1].v=80050094
+Entity.point[2].v=80050097
+Entity.normal.v=8005009e
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005009e
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050081
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000127604
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=8005009f
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=800500a0
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=800500a1
+Entity.point[1].v=800500a2
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a1
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a2
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a3
+Entity.type=11000
+Entity.construction=1
+Entity.point[0].v=800500a4
+Entity.point[1].v=800500a5
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a4
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a5
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.10000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a6
+Entity.type=5000
+Entity.construction=1
+Entity.point[0].v=00230001
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=3.85000000000000008882
+Entity.actPoint.z=-43.25000000000000000000
+Entity.actNormal.vx=-0.00000000000000022204
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a7
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000000000
+Entity.actPoint.z=0.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=800500a8
+Entity.type=14000
+Entity.construction=1
+Entity.point[0].v=8005008b
+Entity.point[1].v=800500a1
+Entity.point[2].v=800500a4
+Entity.normal.v=800500a9
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500a9
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005008b
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000127604
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500aa
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=0.00000000000000355271
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=800500ab
+Entity.type=14000
+Entity.construction=1
+Entity.point[0].v=8005008e
+Entity.point[1].v=800500a2
+Entity.point[2].v=800500a5
+Entity.normal.v=800500ac
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500ac
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005008e
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000158475
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500ad
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=800500b0
+Entity.type=2012
+Entity.construction=1
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=800500b1
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=800500b2
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500b2
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500b3
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=800500b4
+Entity.actNormal.w=0.50000000000000000000
+Entity.actNormal.vx=-0.50000000000000000000
+Entity.actNormal.vy=0.50000000000000000000
+Entity.actNormal.vz=-0.50000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500b4
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500b5
+Entity.type=2012
+Entity.construction=1
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=0
+AddEntity
+
+Entity.h.v=800500b6
+Entity.type=14000
+Entity.construction=1
+Entity.point[0].v=800500b5
+Entity.point[1].v=800500b2
+Entity.point[2].v=800500b4
+Entity.normal.v=800500b7
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500b7
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=800500b5
+Entity.actNormal.w=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c0
+Entity.type=5000
+Entity.construction=0
+Entity.point[0].v=00160001
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=2.70000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actNormal.vx=-0.00000000000000022204
+Entity.actNormal.vz=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c2
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=800500c3
+Entity.point[1].v=800500c4
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c3
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c4
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c5
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=800500c6
+Entity.point[1].v=800500c7
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c6
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actPoint.z=1.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c7
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c8
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=80050099
+Entity.point[1].v=800500c3
+Entity.point[2].v=800500c6
+Entity.normal.v=800500c9
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500c9
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=80050099
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500ca
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=8005009c
+Entity.point[1].v=800500c4
+Entity.point[2].v=800500c7
+Entity.normal.v=800500cb
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500cb
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=8005009c
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=-0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000002643
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500cc
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=800500cd
+Entity.point[1].v=800500ce
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500cd
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500ce
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500cf
+Entity.type=11000
+Entity.construction=0
+Entity.point[0].v=800500d0
+Entity.point[1].v=800500d1
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500d0
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.20000000000000017764
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500d1
+Entity.type=2012
+Entity.construction=0
+Entity.actPoint.x=-0.00000000000000022204
+Entity.actPoint.y=4.59999999999999964473
+Entity.actPoint.z=-16.00000000000000000000
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500d2
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=800500a7
+Entity.point[1].v=800500cd
+Entity.point[2].v=800500d0
+Entity.normal.v=800500d3
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500d3
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=800500a7
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=-0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000002643
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500d4
+Entity.type=14000
+Entity.construction=0
+Entity.point[0].v=800500aa
+Entity.point[1].v=800500ce
+Entity.point[2].v=800500d1
+Entity.normal.v=800500d5
+Entity.actVisible=1
+AddEntity
+
+Entity.h.v=800500d5
+Entity.type=3010
+Entity.construction=0
+Entity.point[0].v=800500aa
+Entity.actNormal.w=1.00000000000000000000
+Entity.actNormal.vx=0.00000000000000000000
+Entity.actNormal.vy=-0.00000000000000011102
+Entity.actNormal.vz=0.00000000000000041030
+Entity.actVisible=1
+AddEntity
+
+Constraint.h.v=00000005
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=80020002
+Constraint.ptB.v=00080001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000e
+Constraint.type=70
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00080001
+Constraint.entityA.v=00090000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000000f
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=00090000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000010
+Constraint.type=100
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=000a0000
+Constraint.entityA.v=00080000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000011
+Constraint.type=100
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=000b0000
+Constraint.entityA.v=00080000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000012
+Constraint.type=41
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=000b0000
+Constraint.entityA.v=00030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000013
+Constraint.type=41
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=000a0000
+Constraint.entityA.v=00030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000014
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=6.20000000000000017764
+Constraint.ptA.v=00090001
+Constraint.ptB.v=00090002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=8.84667408153215895084
+Constraint.disp.offset.y=-0.51504440715899957315
+AddConstraint
+
+Constraint.h.v=00000015
+Constraint.type=1000
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=overall shaft size
+Constraint.disp.offset.x=5.35497829213477061217
+Constraint.disp.offset.y=1.38953450617316964788
+AddConstraint
+
+Constraint.h.v=00000016
+Constraint.type=1000
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=widest part of blade plus clearance (.2)
+Constraint.disp.offset.x=10.85011130033093706970
+Constraint.disp.offset.y=-0.03381015826848848826
+AddConstraint
+
+Constraint.h.v=00000017
+Constraint.type=20
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.ptA.v=80030002
+Constraint.ptB.v=000c0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000018
+Constraint.type=80
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.entityA.v=000c0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000001d
+Constraint.type=81
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.entityA.v=000f0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000001e
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=5.40000000000000035527
+Constraint.ptA.v=000f0001
+Constraint.ptB.v=000f0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=-4.64052190409615228361
+Constraint.disp.offset.y=0.19837685496698967413
+AddConstraint
+
+Constraint.h.v=0000001f
+Constraint.type=70
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00080001
+Constraint.entityA.v=000f0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000020
+Constraint.type=1000
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=width of tip plus clearance (0.2)
+Constraint.disp.offset.x=-7.37874130053942600682
+Constraint.disp.offset.y=0.02379804532428153596
+AddConstraint
+
+Constraint.h.v=00000021
+Constraint.type=30
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.valA=16.00000000000000000000
+Constraint.ptA.v=000c0001
+Constraint.ptB.v=000c0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.y=-0.77886565822649400648
+AddConstraint
+
+Constraint.h.v=00000022
+Constraint.type=1000
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=tip to widest part
+Constraint.disp.offset.x=0.00000000000000095797
+Constraint.disp.offset.y=-1.56932112647957588969
+Constraint.disp.offset.z=-4.31432246999917445862
+AddConstraint
+
+Constraint.h.v=00000024
+Constraint.type=1000
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=tip to normal shaft start
+Constraint.disp.offset.x=0.00000000000000219476
+Constraint.disp.offset.y=4.11682811393839198644
+Constraint.disp.offset.z=-9.88432911174712280911
+AddConstraint
+
+Constraint.h.v=00000025
+Constraint.type=20
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.ptA.v=000c0002
+Constraint.ptB.v=00100001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000026
+Constraint.type=80
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.entityA.v=00100000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000027
+Constraint.type=30
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.valA=27.00000000000000000000
+Constraint.ptA.v=00100002
+Constraint.ptB.v=80030002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.y=1.12156654784615117393
+AddConstraint
+
+Constraint.h.v=00000028
+Constraint.type=20
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.ptA.v=00100002
+Constraint.ptB.v=00110001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000029
+Constraint.type=80
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.entityA.v=00110000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000002a
+Constraint.type=30
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.valA=20.00000000000000000000
+Constraint.ptA.v=00110001
+Constraint.ptB.v=00110002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=0.00000000000000011701
+Constraint.disp.offset.y=1.97905154452726272929
+Constraint.disp.offset.z=-0.52696103271459004969
+AddConstraint
+
+Constraint.h.v=0000002b
+Constraint.type=1000
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=additional sleeve over shaft desired
+Constraint.disp.offset.x=0.00000000000000765162
+Constraint.disp.offset.y=4.39203241799375554422
+Constraint.disp.offset.z=-34.45981316406729888513
+AddConstraint
+
+Constraint.h.v=0000002c
+Constraint.type=20
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.ptA.v=80030002
+Constraint.ptB.v=00120001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000002d
+Constraint.type=80
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.entityA.v=00120000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000002e
+Constraint.type=30
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.valA=1.00000000000000000000
+Constraint.ptA.v=00120001
+Constraint.ptB.v=00120002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=-0.00000000000000000415
+Constraint.disp.offset.y=1.70881452070705197599
+Constraint.disp.offset.z=0.01869733946340202541
+AddConstraint
+
+Constraint.h.v=0000002f
+Constraint.type=1000
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=extent of sleeve past tip
+Constraint.disp.offset.x=-0.00000000000000076682
+Constraint.disp.offset.y=3.47769775587699925268
+Constraint.disp.offset.z=3.45345608282686278301
+AddConstraint
+
+Constraint.h.v=00000030
+Constraint.type=100
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00130000
+Constraint.entityA.v=00080000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000031
+Constraint.type=100
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00140000
+Constraint.entityA.v=00080000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000032
+Constraint.type=42
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valP.v=40000032
+Constraint.ptA.v=00140000
+Constraint.entityA.v=00090000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000033
+Constraint.type=42
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valP.v=40000033
+Constraint.ptA.v=00130000
+Constraint.entityA.v=00090000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000034
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=000f0001
+Constraint.ptB.v=00150001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000035
+Constraint.type=81
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00150000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000036
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00150002
+Constraint.ptB.v=00160001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000003a
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00150002
+Constraint.ptB.v=80040002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000003b
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00150001
+Constraint.ptB.v=00180001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000003c
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00180002
+Constraint.ptB.v=000c0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000003e
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00180002
+Constraint.ptB.v=00190001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000048
+Constraint.type=81
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00190000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000004a
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00190002
+Constraint.ptB.v=001d0002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000004b
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00190002
+Constraint.ptB.v=00110002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000004c
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=001d0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000004d
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=001d0001
+Constraint.ptB.v=001e0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000004e
+Constraint.type=81
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=001e0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000004f
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=001e0002
+Constraint.ptB.v=001f0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000050
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=001f0002
+Constraint.ptB.v=00200001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000051
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00200002
+Constraint.ptB.v=00210001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000052
+Constraint.type=81
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00210000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000054
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=40000054
+Constraint.ptA.v=001e0002
+Constraint.entityA.v=00210000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000055
+Constraint.type=50
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=001f0000
+Constraint.entityB.v=00200000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000056
+Constraint.type=122
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00200000
+Constraint.entityB.v=001f0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000057
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00220000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000058
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=001f0002
+Constraint.ptB.v=00220002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000059
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=001f0002
+Constraint.ptB.v=00230001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000005a
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00230000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000005b
+Constraint.type=42
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.valP.v=4000005b
+Constraint.ptA.v=00230002
+Constraint.entityA.v=00190000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000005c
+Constraint.type=81
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00220001
+Constraint.ptB.v=00200002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000005d
+Constraint.type=50
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00230000
+Constraint.entityB.v=00220000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000005e
+Constraint.type=42
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.valP.v=4000005e
+Constraint.ptA.v=00240000
+Constraint.entityA.v=00110000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000005f
+Constraint.type=30
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.valA=3.00000000000000000000
+Constraint.ptA.v=00240000
+Constraint.ptB.v=00110002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.y=-2.32823414806979345215
+AddConstraint
+
+Constraint.h.v=00000060
+Constraint.type=1000
+Constraint.group.v=00000003
+Constraint.workplane.v=80030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=distance to center of retaining groove
+Constraint.disp.offset.x=0.00000000000000982414
+Constraint.disp.offset.y=-4.01125263817638355590
+Constraint.disp.offset.z=-44.24399310080806912993
+AddConstraint
+
+Constraint.h.v=00000061
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=001e0002
+Constraint.ptB.v=00240000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000063
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00160000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000064
+Constraint.type=81
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00180002
+Constraint.ptB.v=00090001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000065
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00080001
+Constraint.ptB.v=00250001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000066
+Constraint.type=100
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00260000
+Constraint.entityA.v=00250000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000067
+Constraint.type=42
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valP.v=40000067
+Constraint.ptA.v=00260000
+Constraint.entityA.v=00090000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000068
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=1.50000000000000000000
+Constraint.ptA.v=00260000
+Constraint.ptB.v=000f0001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=-2.47126165465868252724
+Constraint.disp.offset.y=0.76087839666451617671
+AddConstraint
+
+Constraint.h.v=00000069
+Constraint.type=1000
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.comment=wall thickness
+Constraint.disp.offset.x=-4.56852521669689970452
+Constraint.disp.offset.y=5.17586828694307232723
+AddConstraint
+
+Constraint.h.v=0000006a
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00160002
+Constraint.ptB.v=00270001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000006b
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00260000
+Constraint.ptB.v=00270002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000006c
+Constraint.type=81
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00270000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000006d
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00270002
+Constraint.ptB.v=00280001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000006e
+Constraint.type=20
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00210002
+Constraint.ptB.v=00280002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=0000006f
+Constraint.type=121
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.entityA.v=00280000
+Constraint.entityB.v=00180000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=00000070
+Constraint.type=80
+Constraint.group.v=00000004
+Constraint.workplane.v=80040000
+Constraint.ptA.v=00210002
+Constraint.ptB.v=00180002
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=000000a1
+Constraint.type=20
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=00080001
+Constraint.ptB.v=00390001
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=000000a2
+Constraint.type=100
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=003a0000
+Constraint.entityA.v=00390000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=000000a3
+Constraint.type=41
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.ptA.v=003a0000
+Constraint.entityA.v=00030000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+AddConstraint
+
+Constraint.h.v=000000a4
+Constraint.type=30
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=0.14999999999999999445
+Constraint.ptA.v=003a0000
+Constraint.ptB.v=000b0000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=2.10961730152424742357
+Constraint.disp.offset.y=-1.49589101069391183785
+AddConstraint
+
+Constraint.h.v=000000a5
+Constraint.type=90
+Constraint.group.v=00000002
+Constraint.workplane.v=80020000
+Constraint.valA=4.75000000000000000000
+Constraint.entityA.v=00390000
+Constraint.other=0
+Constraint.other2=0
+Constraint.reference=0
+Constraint.disp.offset.x=3.85841448220705052208
+Constraint.disp.offset.y=1.33240987349268324991
+Constraint.disp.offset.z=-0.91536661918319117692
+AddConstraint
+
+Surface 00000001 00646464 00000000 1 2
+SCtrl 0 0 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 2.69999999999999973355 2.70000000000000017764 0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 0 2 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 1 0 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 3.09999999999999875655 3.10000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000a 1 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000  -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000
+TrimBy 00000002 0 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000  2.70000000000000017764 0.00000000000000038737 0.00000000000000059952
+TrimBy 00000003 0 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952  3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000
+TrimBy 00000001 1 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000  -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000
+AddSurface
+Surface 00000002 00646464 00000000 1 2
+SCtrl 0 0 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 0 1 2.70000000000000017764 -2.69999999999999928946 0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 0 2 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 3.10000000000000675016 -3.09999999999999520384 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000c 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000  3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000
+TrimBy 00000004 0 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952  0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+TrimBy 00000005 0 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000  0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+TrimBy 00000003 1 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000  2.70000000000000017764 0.00000000000000038737 0.00000000000000059952
+AddSurface
+Surface 00000003 00646464 00000000 1 2
+SCtrl 0 0 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -2.69999999999999928946 -2.70000000000000062172 -0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 0 2 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -3.09999999999999165112 -3.10000000000000364153 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000000e 1 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000  0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+TrimBy 00000006 0 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000  -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952
+TrimBy 00000007 0 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952  -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000
+TrimBy 00000005 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000  0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+AddSurface
+Surface 00000004 00646464 00000000 1 2
+SCtrl 0 0 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 0 1 -2.70000000000000062172 2.69999999999999884537 -0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 0 2 -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -3.10000000000000008882 3.09999999999999475975 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000008 0 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952  -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000
+TrimBy 00000001 0 -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000  -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000
+TrimBy 00000010 1 -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000  -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000
+TrimBy 00000007 1 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000  -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952
+AddSurface
+Surface 00000005 00646464 00000000 2 1
+SCtrl 0 0 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 3.09999999999999875655 3.10000000000000985878 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 3.09999999999999875655 3.10000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000012 1 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000  -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000
+TrimBy 0000000a 0 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000  3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000
+TrimBy 0000000b 0 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000  3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000
+TrimBy 00000009 1 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000  -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000
+AddSurface
+Surface 00000006 00646464 00000000 2 1
+SCtrl 0 0 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 3.10000000000002007283 -3.09999999999998854250 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 3.10000000000000675016 -3.09999999999999520384 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000014 1 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000  3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000
+TrimBy 0000000c 0 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000  0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+TrimBy 0000000d 0 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000  0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000
+TrimBy 0000000b 1 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000  3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000
+AddSurface
+Surface 00000007 00646464 00000000 2 1
+SCtrl 0 0 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -3.09999999999997744027 -3.10000000000001030287 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 -3.09999999999999165112 -3.10000000000000364153 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000016 1 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000  0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000
+TrimBy 0000000e 0 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000  -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000
+TrimBy 0000000f 0 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000  -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000
+TrimBy 0000000d 1 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000  0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+AddSurface
+Surface 00000008 00646464 00000000 2 1
+SCtrl 0 0 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -3.09999999999999964473 3.09999999999998809841 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 -3.10000000000000008882 3.09999999999999475975 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 -0.00000000000000098133 3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000010 0 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000  -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000
+TrimBy 00000009 0 -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000  -0.00000000000000098133 3.10000000000000008882 -47.00000000000000000000
+TrimBy 00000018 1 -0.00000000000000098133 3.10000000000000008882 -47.00000000000000000000  -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000
+TrimBy 0000000f 1 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000  -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000
+AddSurface
+Surface 00000009 00646464 80050056 1 1
+SCtrl 0 0 4.79839999967815700188 -4.79839999967812325110 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 4.79839999967813390924 4.79839999967814634374 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.79839999967811259296 -4.79839999967814634374 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -4.79839999967813568560 4.79839999967812325110 -47.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000018 0 -3.09999999999998854250 -0.00000000000001199041 -47.00000000000000000000  0.00000000000000000000 3.10000000000000008882 -47.00000000000000000000
+TrimBy 00000012 0 0.00000000000000000000 3.10000000000000008882 -47.00000000000000000000  3.10000000000001119105 0.00000000000001071365 -47.00000000000000710543
+TrimBy 00000014 0 3.10000000000001119105 0.00000000000001071365 -47.00000000000000710543  0.00000000000002220446 -3.10000000000000008882 -47.00000000000000710543
+TrimBy 00000016 0 0.00000000000002220446 -3.10000000000000008882 -47.00000000000000710543  -3.09999999999998854250 -0.00000000000001199041 -47.00000000000000000000
+TrimBy 0000001c 1 0.00000000000002153139 -4.59999999999999964473 -46.99999999999999289457  4.60000000000001030287 0.00000000000001040834 -47.00000000000000000000
+TrimBy 0000001a 1 4.60000000000001030287 0.00000000000001040834 -47.00000000000000000000  0.00000000000000000000 4.60000000000000142109 -47.00000000000000710543
+TrimBy 00000020 1 -0.00000000000000133227 4.59999999999999964473 -47.00000000000000000000  -4.59999999999998721023 -0.00000000000001110223 -47.00000000000000000000
+TrimBy 0000001e 1 -4.59999999999998721023 -0.00000000000001110223 -47.00000000000000000000  0.00000000000002153139 -4.59999999999999964473 -46.99999999999999289457
+AddSurface
+Surface 0000000a 00646464 00000000 2 1
+SCtrl 0 0 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 4.59999999999999875655 4.60000000000000941469 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 4.59999999999999875655 4.60000000000000941469 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000022 1 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000  -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000
+TrimBy 0000001a 0 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000  4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000
+TrimBy 0000001b 0 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000  4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000
+TrimBy 00000019 1 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000  -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000
+AddSurface
+Surface 0000000b 00646464 00000000 2 1
+SCtrl 0 0 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 4.60000000000001918465 -4.59999999999998809841 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 4.60000000000002007283 -4.59999999999998809841 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000024 1 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000  4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000
+TrimBy 0000001c 0 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000  0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000
+TrimBy 0000001d 0 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000  0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+TrimBy 0000001b 1 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000  4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000
+AddSurface
+Surface 0000000c 00646464 00000000 2 1
+SCtrl 0 0 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.59999999999997832845 -4.60000000000000941469 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 -4.59999999999997744027 -4.60000000000001030287 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000026 1 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000  0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+TrimBy 0000001e 0 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000  -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000
+TrimBy 0000001f 0 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000  -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000
+TrimBy 0000001d 1 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000  0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000
+AddSurface
+Surface 0000000d 00646464 00000000 2 1
+SCtrl 0 0 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.60000000000000053291 4.59999999999998809841 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 -4.60000000000000053291 4.59999999999998721023 -47.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -0.00000000000000134872 4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000020 0 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000  -0.00000000000000134872 4.59999999999999964473 -47.00000000000000000000
+TrimBy 00000019 0 -0.00000000000000134872 4.59999999999999964473 -47.00000000000000000000  -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000
+TrimBy 00000028 1 -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000  -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000
+TrimBy 0000001f 1 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000  -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000
+AddSurface
+Surface 0000000e 00646464 00000000 1 2
+SCtrl 0 0 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 4.59999999999999875655 4.60000000000000941469 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 3.84999999999999920064 3.85000000000000941469 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000002a 1 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000  -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000
+TrimBy 00000022 0 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000  4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000
+TrimBy 00000023 0 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000  3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000
+TrimBy 00000021 1 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000  -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000
+AddSurface
+Surface 0000000f 00646464 00000000 1 2
+SCtrl 0 0 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 4.60000000000001918465 -4.59999999999998809841 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 3.85000000000001918465 -3.84999999999998898659 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000002c 1 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000  3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000
+TrimBy 00000024 0 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000  0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+TrimBy 00000025 0 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000  0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+TrimBy 00000023 1 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000  4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000
+AddSurface
+Surface 00000010 00646464 00000000 1 2
+SCtrl 0 0 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -4.59999999999997832845 -4.60000000000000941469 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -3.84999999999997877254 -3.85000000000000985878 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000002e 1 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000  0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+TrimBy 00000026 0 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000  -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000
+TrimBy 00000027 0 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000  -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000
+TrimBy 00000025 1 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000  0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+AddSurface
+Surface 00000011 00646464 00000000 1 2
+SCtrl 0 0 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -4.60000000000000053291 4.59999999999998809841 -44.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -3.85000000000000053291 3.84999999999998854250 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000028 0 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000  -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000
+TrimBy 00000021 0 -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000  -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000
+TrimBy 00000030 1 -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000  -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000
+TrimBy 00000027 1 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000  -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000
+AddSurface
+Surface 00000012 00646464 00000000 1 2
+SCtrl 0 0 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 3.84999999999999920064 3.85000000000000941469 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 4.59999999999999964473 4.60000000000000852651 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000032 1 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000  -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000
+TrimBy 0000002a 0 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000  3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000
+TrimBy 0000002b 0 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000  4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000
+TrimBy 00000029 1 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000  -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000
+AddSurface
+Surface 00000013 00646464 00000000 1 2
+SCtrl 0 0 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 3.85000000000001918465 -3.84999999999998898659 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 4.60000000000001829648 -4.59999999999998898659 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000034 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000  4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000
+TrimBy 0000002c 0 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000  0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+TrimBy 0000002d 0 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000  0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+TrimBy 0000002b 1 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000  3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000
+AddSurface
+Surface 00000014 00646464 00000000 1 2
+SCtrl 0 0 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -3.84999999999997877254 -3.85000000000000985878 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -4.59999999999997832845 -4.60000000000000941469 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000036 1 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000  0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+TrimBy 0000002e 0 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000  -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000
+TrimBy 0000002f 0 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000  -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000
+TrimBy 0000002d 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000  0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+AddSurface
+Surface 00000015 00646464 00000000 1 2
+SCtrl 0 0 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -3.85000000000000053291 3.84999999999998854250 -43.25000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -4.60000000000000053291 4.59999999999998809841 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 2 -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000030 0 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000  -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000
+TrimBy 00000029 0 -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000  -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000
+TrimBy 00000038 1 -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000  -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000
+TrimBy 0000002f 1 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000  -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000
+AddSurface
+Surface 00000016 00646464 00000000 2 1
+SCtrl 0 0 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 4.59999999999999875655 4.60000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 4.59999999999999964473 4.60000000000000852651 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364 Weight 1.00000000000000000000
+SCtrl 2 1 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000003a 1 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364  -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000
+TrimBy 00000032 0 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000  4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000
+TrimBy 00000033 0 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000  4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364
+TrimBy 00000031 1 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000  -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000
+AddSurface
+Surface 00000017 00646464 00000000 2 1
+SCtrl 0 0 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364 Weight 1.00000000000000000000
+SCtrl 0 1 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 4.60000000000000675016 -4.59999999999999431566 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 4.60000000000001829648 -4.59999999999998898659 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000003c 1 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000  4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364
+TrimBy 00000034 0 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000  0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+TrimBy 00000035 0 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000  0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+TrimBy 00000033 1 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364  4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000
+AddSurface
+Surface 00000018 00646464 00000000 2 1
+SCtrl 0 0 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.59999999999999076294 -4.60000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 -4.59999999999997832845 -4.60000000000000941469 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000003e 1 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000  0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+TrimBy 00000036 0 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000  -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000
+TrimBy 00000037 0 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000  -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000
+TrimBy 00000035 1 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000  0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+AddSurface
+Surface 00000019 00646464 00000000 2 1
+SCtrl 0 0 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.60000000000000053291 4.59999999999999431566 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 1 1 -4.60000000000000053291 4.59999999999998809841 -42.50000000000000000000 Weight 0.70710678118654757274
+SCtrl 2 0 -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000038 0 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000  -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000
+TrimBy 00000031 0 -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000  -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000
+TrimBy 00000040 1 -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000  -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000
+TrimBy 00000037 1 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000  -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000
+AddSurface
+Surface 0000001a 00646464 00000000 1 2
+SCtrl 0 0 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 4.59999999999999875655 4.60000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364 Weight 1.00000000000000000000
+SCtrl 1 0 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 4.19999999999999928946 4.20000000000000017764 0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 1 2 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259 Weight 1.00000000000000000000
+TrimBy 00000042 1 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259  -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000
+TrimBy 0000003a 0 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000  4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364
+TrimBy 0000003b 0 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364  4.20000000000000017764 0.00000000000000047922 0.00000000000000093259
+TrimBy 00000039 1 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000  -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000
+AddSurface
+Surface 0000001b 00646464 00000000 1 2
+SCtrl 0 0 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364 Weight 1.00000000000000000000
+SCtrl 0 1 4.60000000000000675016 -4.59999999999999431566 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259 Weight 1.00000000000000000000
+SCtrl 1 1 4.20000000000000017764 -4.19999999999999840128 0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 1 2 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000044 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000  4.20000000000000017764 0.00000000000000047922 0.00000000000000093259
+TrimBy 0000003c 0 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364  0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+TrimBy 0000003d 0 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000  0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+TrimBy 0000003b 1 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259  4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364
+AddSurface
+Surface 0000001c 00646464 00000000 1 2
+SCtrl 0 0 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -4.59999999999999076294 -4.60000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 1 -4.19999999999999840128 -4.20000000000000017764 -0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 1 2 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259 Weight 1.00000000000000000000
+TrimBy 00000046 1 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259  0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+TrimBy 0000003e 0 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000  -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000
+TrimBy 0000003f 0 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000  -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259
+TrimBy 0000003d 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000  0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+AddSurface
+Surface 0000001d 00646464 00000000 1 2
+SCtrl 0 0 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -4.60000000000000053291 4.59999999999999431566 -16.00000000000000000000 Weight 0.70710678118654757274
+SCtrl 0 2 -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259 Weight 1.00000000000000000000
+SCtrl 1 1 -4.20000000000000017764 4.19999999999999840128 -0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 1 2 -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000040 0 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000  -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000
+TrimBy 00000039 0 -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000  -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000
+TrimBy 00000048 1 -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000  -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259
+TrimBy 0000003f 1 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259  -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000
+AddSurface
+Surface 0000001e 00646464 00000000 2 1
+SCtrl 0 0 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 4.20000000000000017764 4.19999999999999928946 1.00000000000000088818 Weight 0.70710678118654757274
+SCtrl 1 1 4.19999999999999928946 4.20000000000000017764 0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 2 0 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818 Weight 1.00000000000000000000
+SCtrl 2 1 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259 Weight 1.00000000000000000000
+TrimBy 0000004a 1 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818  -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000
+TrimBy 00000042 0 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000  4.20000000000000017764 0.00000000000000047922 0.00000000000000093259
+TrimBy 00000043 0 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259  4.20000000000000017764 0.00000000000000025718 1.00000000000000088818
+TrimBy 00000041 1 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000  -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000
+AddSurface
+Surface 0000001f 00646464 00000000 2 1
+SCtrl 0 0 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818 Weight 1.00000000000000000000
+SCtrl 0 1 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259 Weight 1.00000000000000000000
+SCtrl 1 0 4.19999999999999928946 -4.19999999999999928946 1.00000000000000088818 Weight 0.70710678118654757274
+SCtrl 1 1 4.20000000000000017764 -4.19999999999999840128 0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 2 0 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 0000004c 1 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000  4.20000000000000017764 0.00000000000000025718 1.00000000000000088818
+TrimBy 00000044 0 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259  0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+TrimBy 00000045 0 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000  0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000
+TrimBy 00000043 1 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818  4.20000000000000017764 0.00000000000000047922 0.00000000000000093259
+AddSurface
+Surface 00000020 00646464 00000000 2 1
+SCtrl 0 0 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -4.19999999999999840128 -4.20000000000000017764 0.99999999999999911182 Weight 0.70710678118654757274
+SCtrl 1 1 -4.19999999999999840128 -4.20000000000000017764 -0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 2 0 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182 Weight 1.00000000000000000000
+SCtrl 2 1 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259 Weight 1.00000000000000000000
+TrimBy 0000004e 1 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182  0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000
+TrimBy 00000046 0 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000  -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259
+TrimBy 00000047 0 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259  -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182
+TrimBy 00000045 1 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000  0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+AddSurface
+Surface 00000021 00646464 00000000 2 1
+SCtrl 0 0 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182 Weight 1.00000000000000000000
+SCtrl 0 1 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259 Weight 1.00000000000000000000
+SCtrl 1 0 -4.20000000000000017764 4.19999999999999840128 0.99999999999999911182 Weight 0.70710678118654757274
+SCtrl 1 1 -4.20000000000000017764 4.19999999999999840128 -0.00000000000000093259 Weight 0.70710678118654757274
+SCtrl 2 0 -0.00000000000000125075 4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000048 0 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259  -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000
+TrimBy 00000041 0 -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000  -0.00000000000000125075 4.20000000000000017764 1.00000000000000000000
+TrimBy 00000050 1 -0.00000000000000125075 4.20000000000000017764 1.00000000000000000000  -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182
+TrimBy 00000047 1 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182  -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259
+AddSurface
+Surface 00000022 00646464 800500c0 1 1
+SCtrl 0 0 -4.38239999967813531612 -4.38239999967813531612 0.99999999999999911182 Weight 1.00000000000000000000
+SCtrl 0 1 -4.38239999967813531612 4.38239999967813531612 0.99999999999999911182 Weight 1.00000000000000000000
+SCtrl 1 0 4.38239999967813531612 -4.38239999967813531612 1.00000000000000088818 Weight 1.00000000000000000000
+SCtrl 1 1 4.38239999967813531612 4.38239999967813531612 1.00000000000000088818 Weight 1.00000000000000000000
+TrimBy 00000050 0 -4.20000000000000017764 -0.00000000000000090206 0.99999999999999922284  -0.00000000000000088818 4.19999999999999928946 1.00000000000000000000
+TrimBy 0000004a 0 0.00000000000000000000 4.19999999999999928946 1.00000000000000000000  4.19999999999999928946 0.00000000000000000000 1.00000000000000088818
+TrimBy 0000004c 0 4.19999999999999928946 0.00000000000000000000 1.00000000000000088818  -0.00000000000000022204 -4.19999999999999928946 1.00000000000000000000
+TrimBy 0000004e 0 -0.00000000000000022204 -4.19999999999999928946 1.00000000000000000000  -4.20000000000000017764 -0.00000000000000090206 0.99999999999999922284
+TrimBy 00000054 1 0.00000000000000000000 -2.70000000000000017764 0.99999999999999988898  2.70000000000000106581 0.00000000000000000000 1.00000000000000044409
+TrimBy 00000052 1 2.70000000000000106581 0.00000000000000000000 1.00000000000000044409  0.00000000000000000000 2.70000000000000106581 1.00000000000000000000
+TrimBy 00000058 1 -0.00000000000000088818 2.70000000000000106581 1.00000000000000000000  -2.70000000000000062172 -0.00000000000000111022 0.99999999999999955591
+TrimBy 00000056 1 -2.70000000000000062172 -0.00000000000000111022 0.99999999999999955591  0.00000000000000000000 -2.70000000000000017764 0.99999999999999988898
+AddSurface
+Surface 00000023 00646464 00000000 2 1
+SCtrl 0 0 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 2.69999999999999973355 2.70000000000000017764 0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 1 1 2.70000000000000017764 2.69999999999999973355 1.00000000000000088818 Weight 0.70710678118654757274
+SCtrl 2 0 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 2 1 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613 Weight 1.00000000000000000000
+TrimBy 00000053 0 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613  2.70000000000000017764 0.00000000000000038737 0.00000000000000059952
+TrimBy 00000002 1 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952  -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000
+TrimBy 00000051 1 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000  -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000
+TrimBy 00000052 0 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000  2.70000000000000017764 0.00000000000000016533 1.00000000000000066613
+AddSurface
+Surface 00000024 00646464 00000000 2 1
+SCtrl 0 0 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 0 1 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613 Weight 1.00000000000000000000
+SCtrl 1 0 2.70000000000000017764 -2.69999999999999928946 0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 1 1 2.70000000000000017764 -2.69999999999999973355 1.00000000000000088818 Weight 0.70710678118654757274
+SCtrl 2 0 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000055 0 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000  0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+TrimBy 00000004 1 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000  2.70000000000000017764 0.00000000000000038737 0.00000000000000059952
+TrimBy 00000053 1 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952  2.70000000000000017764 0.00000000000000016533 1.00000000000000066613
+TrimBy 00000054 0 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613  0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000
+AddSurface
+Surface 00000025 00646464 00000000 2 1
+SCtrl 0 0 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 0 1 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 1 0 -2.69999999999999928946 -2.70000000000000062172 -0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 1 1 -2.70000000000000017764 -2.70000000000000017764 0.99999999999999955591 Weight 0.70710678118654757274
+SCtrl 2 0 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 2 1 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489 Weight 1.00000000000000000000
+TrimBy 00000057 0 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489  -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952
+TrimBy 00000006 1 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952  0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+TrimBy 00000055 1 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000  0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000
+TrimBy 00000056 0 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000  -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489
+AddSurface
+Surface 00000026 00646464 00000000 2 1
+SCtrl 0 0 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952 Weight 1.00000000000000000000
+SCtrl 0 1 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489 Weight 1.00000000000000000000
+SCtrl 1 0 -2.70000000000000062172 2.69999999999999884537 -0.00000000000000059952 Weight 0.70710678118654757274
+SCtrl 1 1 -2.70000000000000106581 2.69999999999999928946 0.99999999999999955591 Weight 0.70710678118654757274
+SCtrl 2 0 -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000 Weight 1.00000000000000000000
+SCtrl 2 1 -0.00000000000000088335 2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+TrimBy 00000058 0 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489  -0.00000000000000088335 2.70000000000000017764 1.00000000000000000000
+TrimBy 00000008 1 -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000  -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952
+TrimBy 00000057 1 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952  -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489
+TrimBy 00000051 0 -0.00000000000000088335 2.70000000000000017764 1.00000000000000000000  -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000
+AddSurface
+Curve 00000001 1 1 00000001 00000004
+CCtrl 0 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000
+AddCurve
+Curve 00000002 1 2 00000001 00000023
+CCtrl 0 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 2.69999999999999973355 2.70000000000000017764 0.00000000000000059952 Weight 0.70710678118654757274
+CCtrl 2 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000
+CurvePt 0 0.24260698232380231709 2.68907825325477212175 0.00000000000000005387
+CurvePt 0 0.49130024151279050315 2.65492449472475122718 0.00000000000000010909
+CurvePt 0 0.74292718008249725159 2.59577718710498528409 0.00000000000000016496
+CurvePt 0 0.99385571581705633992 2.51042841286856210914 0.00000000000000022068
+CurvePt 0 1.24009540125120909515 2.39836681844033261513 0.00000000000000027536
+CurvePt 0 1.47746633413988459615 2.25988788029035836402 0.00000000000000032806
+CurvePt 0 1.70180494127792214520 2.09615360645207671197 0.00000000000000037788
+CurvePt 0 1.90918830920367832427 1.90918830920367854631 0.00000000000000042392
+CurvePt 0 2.09615360645207671197 1.70180494127792281134 0.00000000000000046544
+CurvePt 0 2.25988788029035836402 1.47746633413988504024 0.00000000000000050180
+CurvePt 0 2.39836681844033261513 1.24009540125120931719 0.00000000000000053254
+CurvePt 0 2.51042841286856210914 0.99385571581705678401 0.00000000000000055743
+CurvePt 0 2.59577718710498484000 0.74292718008249769568 0.00000000000000057638
+CurvePt 0 2.65492449472475122718 0.49130024151279100275 0.00000000000000058951
+CurvePt 0 2.68907825325477212175 0.24260698232380292771 0.00000000000000059710
+CurvePt 1 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952
+AddCurve
+Curve 00000003 1 1 00000002 00000001
+CCtrl 0 2.70000000000000017764 0.00000000000000082157 0.00000000000000059952 Weight 1.00000000000000000000
+CCtrl 1 3.10000000000000364153 0.00000000000000446310 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 2.70000000000000017764 0.00000000000000082157 0.00000000000000059952
+CurvePt 1 3.10000000000000364153 0.00000000000000446310 -16.00000000000000000000
+AddCurve
+Curve 00000004 1 2 00000002 00000024
+CCtrl 0 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952 Weight 1.00000000000000000000
+CCtrl 1 2.70000000000000017764 -2.69999999999999928946 0.00000000000000059952 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 2.70000000000000017764 0.00000000000000038737 0.00000000000000059952
+CurvePt 0 2.68907825325477212175 -0.24260698232380215056 0.00000000000000059710
+CurvePt 0 2.65492449472475122718 -0.49130024151279033662 0.00000000000000058951
+CurvePt 0 2.59577718710498528409 -0.74292718008249702955 0.00000000000000057638
+CurvePt 0 2.51042841286856210914 -0.99385571581705600686 0.00000000000000055743
+CurvePt 0 2.39836681844033261513 -1.24009540125120842902 0.00000000000000053254
+CurvePt 0 2.25988788029035836402 -1.47746633413988437411 0.00000000000000050180
+CurvePt 0 2.09615360645207671197 -1.70180494127792214520 0.00000000000000046544
+CurvePt 0 1.90918830920367876836 -1.90918830920367810222 0.00000000000000042392
+CurvePt 0 1.70180494127792281134 -2.09615360645207626789 0.00000000000000037788
+CurvePt 0 1.47746633413988504024 -2.25988788029035791993 0.00000000000000032806
+CurvePt 0 1.24009540125120931719 -2.39836681844033261513 0.00000000000000027536
+CurvePt 0 0.99385571581705689503 -2.51042841286856166505 0.00000000000000022068
+CurvePt 0 0.74292718008249780670 -2.59577718710498484000 0.00000000000000016496
+CurvePt 0 0.49130024151279122480 -2.65492449472475078309 0.00000000000000010909
+CurvePt 0 0.24260698232380309425 -2.68907825325477212175 0.00000000000000005387
+CurvePt 1 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+AddCurve
+Curve 00000005 1 1 00000003 00000002
+CCtrl 0 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+CurvePt 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+AddCurve
+Curve 00000006 1 2 00000003 00000025
+CCtrl 0 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -2.69999999999999928946 -2.70000000000000062172 -0.00000000000000059952 Weight 0.70710678118654757274
+CCtrl 2 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+CurvePt 0 -0.24260698232380198403 -2.68907825325477212175 -0.00000000000000005387
+CurvePt 0 -0.49130024151279011457 -2.65492449472475122718 -0.00000000000000010909
+CurvePt 0 -0.74292718008249691852 -2.59577718710498528409 -0.00000000000000016496
+CurvePt 0 -0.99385571581705600686 -2.51042841286856210914 -0.00000000000000022068
+CurvePt 0 -1.24009540125120842902 -2.39836681844033261513 -0.00000000000000027536
+CurvePt 0 -1.47746633413988437411 -2.25988788029035836402 -0.00000000000000032806
+CurvePt 0 -1.70180494127792214520 -2.09615360645207715606 -0.00000000000000037788
+CurvePt 0 -1.90918830920367810222 -1.90918830920367899040 -0.00000000000000042392
+CurvePt 0 -2.09615360645207626789 -1.70180494127792281134 -0.00000000000000046544
+CurvePt 0 -2.25988788029035791993 -1.47746633413988526229 -0.00000000000000050180
+CurvePt 0 -2.39836681844033261513 -1.24009540125120976128 -0.00000000000000053254
+CurvePt 0 -2.51042841286856166505 -0.99385571581705733912 -0.00000000000000055743
+CurvePt 0 -2.59577718710498484000 -0.74292718008249813977 -0.00000000000000057638
+CurvePt 0 -2.65492449472475078309 -0.49130024151279144684 -0.00000000000000058951
+CurvePt 0 -2.68907825325477212175 -0.24260698232380326078 -0.00000000000000059710
+CurvePt 1 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952
+AddCurve
+Curve 00000007 1 1 00000004 00000003
+CCtrl 0 -2.70000000000000017764 -0.00000000000000082157 -0.00000000000000059952 Weight 1.00000000000000000000
+CCtrl 1 -3.09999999999999653610 -0.00000000000000446310 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -2.70000000000000017764 -0.00000000000000082157 -0.00000000000000059952
+CurvePt 1 -3.09999999999999653610 -0.00000000000000446310 -16.00000000000000000000
+AddCurve
+Curve 00000008 1 2 00000004 00000026
+CCtrl 0 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952 Weight 1.00000000000000000000
+CCtrl 1 -2.70000000000000062172 2.69999999999999884537 -0.00000000000000059952 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -2.70000000000000017764 -0.00000000000000071803 -0.00000000000000059952
+CurvePt 0 -2.68907825325477212175 0.24260698232380181749 -0.00000000000000059710
+CurvePt 0 -2.65492449472475122718 0.49130024151278994804 -0.00000000000000058951
+CurvePt 0 -2.59577718710498528409 0.74292718008249658546 -0.00000000000000057638
+CurvePt 0 -2.51042841286856210914 0.99385571581705578481 -0.00000000000000055743
+CurvePt 0 -2.39836681844033261513 1.24009540125120820697 -0.00000000000000053254
+CurvePt 0 -2.25988788029035880811 1.47746633413988415207 -0.00000000000000050180
+CurvePt 0 -2.09615360645207715606 1.70180494127792192316 -0.00000000000000046544
+CurvePt 0 -1.90918830920367899040 1.90918830920367788018 -0.00000000000000042392
+CurvePt 0 -1.70180494127792281134 2.09615360645207626789 -0.00000000000000037788
+CurvePt 0 -1.47746633413988570638 2.25988788029035791993 -0.00000000000000032806
+CurvePt 0 -1.24009540125120976128 2.39836681844033172695 -0.00000000000000027536
+CurvePt 0 -0.99385571581705733912 2.51042841286856166505 -0.00000000000000022068
+CurvePt 0 -0.74292718008249825079 2.59577718710498484000 -0.00000000000000016496
+CurvePt 0 -0.49130024151279155786 2.65492449472475078309 -0.00000000000000010909
+CurvePt 0 -0.24260698232380342731 2.68907825325477212175 -0.00000000000000005387
+CurvePt 1 -0.00000000000000088335 2.70000000000000017764 -0.00000000000000000000
+AddCurve
+Curve 00000009 1 1 00000005 00000008
+CCtrl 0 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000
+AddCurve
+Curve 0000000a 1 2 00000005 00000001
+CCtrl 0 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.09999999999999875655 3.10000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.10000000000000008882 -16.00000000000000000000
+CurvePt 0 0.27854875748288410175 3.08746021669992387615 -15.99999999999999822364
+CurvePt 0 0.56408546247764834725 3.04824664209138118665 -16.00000000000000000000
+CurvePt 0 0.85299046602064487743 2.98033677037979849445 -16.00000000000000000000
+CurvePt 0 1.14109359964180545610 2.88234373329353532611 -16.00000000000000000000
+CurvePt 0 1.42381323847361018764 2.75368042117223499332 -15.99999999999999822364
+CurvePt 0 1.69635023549394192699 2.59468608477782058941 -15.99999999999999822364
+CurvePt 0 1.95392419183761489876 2.40669488148201571320 -16.00000000000000000000
+CurvePt 0 2.19203102167829788627 2.19203102167830010671 -16.00000000000000000000
+CurvePt 0 2.40669488148201482502 1.95392419183761756329 -16.00000000000000000000
+CurvePt 0 2.59468608477782014532 1.69635023549394503561 -15.99999999999999822364
+CurvePt 0 2.75368042117223499332 1.42381323847361351831 -15.99999999999999822364
+CurvePt 0 2.88234373329353577020 1.14109359964180900882 -16.00000000000000000000
+CurvePt 0 2.98033677037980027080 0.85299046602064876321 -16.00000000000000000000
+CurvePt 0 3.04824664209138340709 0.56408546247765234405 -16.00000000000000000000
+CurvePt 0 3.08746021669992654068 0.27854875748288832060 -15.99999999999999822364
+CurvePt 1 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000
+AddCurve
+Curve 0000000b 1 1 00000006 00000005
+CCtrl 0 3.10000000000000364153 0.00000000000000446310 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.10000000000001030287 0.00000000000001134648 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 3.10000000000000364153 0.00000000000000446310 -16.00000000000000000000
+CurvePt 1 3.10000000000001030287 0.00000000000001134648 -47.00000000000000000000
+AddCurve
+Curve 0000000c 1 2 00000006 00000002
+CCtrl 0 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.10000000000000675016 -3.09999999999999520384 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 3.10000000000000364153 0.00000000000000396458 -16.00000000000000000000
+CurvePt 0 3.08746021669992742886 -0.27854875748288038251 -15.99999999999999822364
+CurvePt 0 3.04824664209138473936 -0.56408546247764457249 -16.00000000000000000000
+CurvePt 0 2.98033677037980249125 -0.85299046602064110267 -16.00000000000000000000
+CurvePt 0 2.88234373329353887883 -1.14109359964180190339 -16.00000000000000000000
+CurvePt 0 2.75368042117223854603 -1.42381323847360663493 -15.99999999999999822364
+CurvePt 0 2.59468608477782414212 -1.69635023549393837428 -15.99999999999999822364
+CurvePt 0 2.40669488148201971001 -1.95392419183761134605 -16.00000000000000000000
+CurvePt 0 2.19203102167830365943 -2.19203102167829433355 -16.00000000000000000000
+CurvePt 0 1.95392419183762089396 -2.40669488148201127231 -16.00000000000000000000
+CurvePt 0 1.69635023549394858833 -2.59468608477781614852 -15.99999999999999822364
+CurvePt 0 1.42381323847361707102 -2.75368042117223144061 -15.99999999999999822364
+CurvePt 0 1.14109359964181300562 -2.88234373329353266158 -16.00000000000000000000
+CurvePt 0 0.85299046602065242695 -2.98033677037979627400 -16.00000000000000000000
+CurvePt 0 0.56408546247765600778 -3.04824664209137985438 -16.00000000000000000000
+CurvePt 0 0.27854875748289203985 -3.08746021669992343206 -15.99999999999999822364
+CurvePt 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+AddCurve
+Curve 0000000d 1 1 00000007 00000006
+CCtrl 0 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+CurvePt 1 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000
+AddCurve
+Curve 0000000e 1 2 00000007 00000003
+CCtrl 0 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.09999999999999165112 -3.10000000000000364153 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000770711 -3.10000000000000008882 -16.00000000000000000000
+CurvePt 0 -0.27854875748287660775 -3.08746021669992387615 -15.99999999999999822364
+CurvePt 0 -0.56408546247764090875 -3.04824664209138118665 -16.00000000000000000000
+CurvePt 0 -0.85299046602063743894 -2.98033677037979849445 -16.00000000000000000000
+CurvePt 0 -1.14109359964179812863 -2.88234373329353532611 -16.00000000000000000000
+CurvePt 0 -1.42381323847360286017 -2.75368042117223543741 -15.99999999999999822364
+CurvePt 0 -1.69635023549393459952 -2.59468608477782058941 -15.99999999999999822364
+CurvePt 0 -1.95392419183760779333 -2.40669488148201660138 -16.00000000000000000000
+CurvePt 0 -2.19203102167829078084 -2.19203102167830010671 -16.00000000000000000000
+CurvePt 0 -2.40669488148200683142 -1.95392419183761756329 -16.00000000000000000000
+CurvePt 0 -2.59468608477781303989 -1.69635023549394525766 -15.99999999999999822364
+CurvePt 0 -2.75368042117222788789 -1.42381323847361396240 -15.99999999999999822364
+CurvePt 0 -2.88234373329352910886 -1.14109359964180945290 -16.00000000000000000000
+CurvePt 0 -2.98033677037979316538 -0.85299046602064920730 -16.00000000000000000000
+CurvePt 0 -3.04824664209137630166 -0.56408546247765267712 -16.00000000000000000000
+CurvePt 0 -3.08746021669991987935 -0.27854875748288865367 -15.99999999999999822364
+CurvePt 1 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000
+AddCurve
+Curve 0000000f 1 1 00000008 00000007
+CCtrl 0 -3.09999999999999653610 -0.00000000000000446310 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.09999999999998943068 -0.00000000000001134648 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -3.09999999999999653610 -0.00000000000000446310 -16.00000000000000000000
+CurvePt 1 -3.09999999999998943068 -0.00000000000001134648 -47.00000000000000000000
+AddCurve
+Curve 00000010 1 2 00000008 00000004
+CCtrl 0 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.10000000000000008882 3.09999999999999475975 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -3.09999999999999653610 -0.00000000000000434422 -16.00000000000000000000
+CurvePt 0 -3.08746021669992032344 0.27854875748287999393 -15.99999999999999822364
+CurvePt 0 -3.04824664209137807802 0.56408546247764423942 -16.00000000000000000000
+CurvePt 0 -2.98033677037979538582 0.85299046602064076961 -16.00000000000000000000
+CurvePt 0 -2.88234373329353177340 1.14109359964180123725 -16.00000000000000000000
+CurvePt 0 -2.75368042117223144061 1.42381323847360641288 -15.99999999999999822364
+CurvePt 0 -2.59468608477781703670 1.69635023549393793019 -15.99999999999999822364
+CurvePt 0 -2.40669488148201260458 1.95392419183761090196 -16.00000000000000000000
+CurvePt 0 -2.19203102167829655400 2.19203102167829433355 -16.00000000000000000000
+CurvePt 0 -1.95392419183761423263 2.40669488148201082822 -16.00000000000000000000
+CurvePt 0 -1.69635023549394170495 2.59468608477781614852 -15.99999999999999822364
+CurvePt 0 -1.42381323847361040968 2.75368042117223099652 -15.99999999999999822364
+CurvePt 0 -1.14109359964180612224 2.88234373329353266158 -16.00000000000000000000
+CurvePt 0 -0.85299046602064576561 2.98033677037979627400 -16.00000000000000000000
+CurvePt 0 -0.56408546247764945747 3.04824664209137985438 -16.00000000000000000000
+CurvePt 0 -0.27854875748288532300 3.08746021669992298797 -15.99999999999999822364
+CurvePt 1 -0.00000000000000098133 3.10000000000000008882 -16.00000000000000000000
+AddCurve
+Curve 00000011 1 1 00000009 00000009
+CCtrl 0 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000
+AddCurve
+Curve 00000012 1 2 00000009 00000005
+CCtrl 0 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.09999999999999875655 3.10000000000000985878 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.10000000000000008882 -47.00000000000000000000
+CurvePt 0 0.27854875748288410175 3.08746021669992432024 -47.00000000000000000000
+CurvePt 0 0.56408546247764845827 3.04824664209138207482 -47.00000000000000000000
+CurvePt 0 0.85299046602064509948 2.98033677037980071489 -47.00000000000000710543
+CurvePt 0 1.14109359964180590019 2.88234373329353799065 -47.00000000000000000000
+CurvePt 0 1.42381323847361085377 2.75368042117223810195 -47.00000000000000000000
+CurvePt 0 1.69635023549394303721 2.59468608477782414212 -47.00000000000000000000
+CurvePt 0 1.95392419183761645307 2.40669488148202059818 -47.00000000000000000000
+CurvePt 0 2.19203102167830010671 2.19203102167830454761 -47.00000000000000710543
+CurvePt 0 2.40669488148201748956 1.95392419183762244828 -47.00000000000000000000
+CurvePt 0 2.59468608477782325394 1.69635023549395080877 -47.00000000000000000000
+CurvePt 0 2.75368042117223854603 1.42381323847361973556 -47.00000000000000000000
+CurvePt 0 2.88234373329353976700 1.14109359964181522606 -47.00000000000000000000
+CurvePt 0 2.98033677037980515578 0.85299046602065542455 -47.00000000000000710543
+CurvePt 0 3.04824664209138918025 0.56408546247765911641 -47.00000000000000000000
+CurvePt 0 3.08746021669993275793 0.27854875748289514847 -47.00000000000000000000
+CurvePt 1 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000
+AddCurve
+Curve 00000013 1 1 00000009 00000009
+CCtrl 0 3.10000000000001030287 0.00000000000001134648 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000001030287 0.00000000000001167955 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 3.10000000000001030287 0.00000000000001134648 -47.00000000000000000000
+CurvePt 1 4.60000000000001030287 0.00000000000001167955 -47.00000000000000000000
+AddCurve
+Curve 00000014 1 2 00000009 00000006
+CCtrl 0 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.10000000000002007283 -3.09999999999998854250 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 3.10000000000001030287 0.00000000000001084796 -47.00000000000000000000
+CurvePt 0 3.08746021669993453429 -0.27854875748287355464 -47.00000000000000000000
+CurvePt 0 3.04824664209139317705 -0.56408546247763780013 -47.00000000000000000000
+CurvePt 0 2.98033677037981092894 -0.85299046602063455236 -47.00000000000000710543
+CurvePt 0 2.88234373329354776061 -1.14109359964179524205 -47.00000000000000000000
+CurvePt 0 2.75368042117224876009 -1.42381323847360041768 -47.00000000000000000000
+CurvePt 0 2.59468608477783524435 -1.69635023549393260112 -47.00000000000000000000
+CurvePt 0 2.40669488148203036815 -1.95392419183760623902 -47.00000000000000000000
+CurvePt 0 2.19203102167831520575 -2.19203102167828944857 -47.00000000000000710543
+CurvePt 0 1.95392419183763332846 -2.40669488148200638733 -47.00000000000000000000
+CurvePt 0 1.69635023549396102283 -2.59468608477781303989 -47.00000000000000000000
+CurvePt 0 1.42381323847363017165 -2.75368042117222788789 -47.00000000000000000000
+CurvePt 0 1.14109359964182566216 -2.88234373329352999704 -47.00000000000000000000
+CurvePt 0 0.85299046602066586065 -2.98033677037979449764 -47.00000000000000710543
+CurvePt 0 0.56408546247766966353 -3.04824664209137896620 -47.00000000000000000000
+CurvePt 0 0.27854875748290569559 -3.08746021669992254388 -47.00000000000000000000
+CurvePt 1 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000
+AddCurve
+Curve 00000015 1 1 00000009 00000009
+CCtrl 0 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000
+CurvePt 1 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000
+AddCurve
+Curve 00000016 1 2 00000009 00000007
+CCtrl 0 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.09999999999997744027 -3.10000000000001030287 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000002147388 -3.10000000000000008882 -47.00000000000000000000
+CurvePt 0 -0.27854875748286289650 -3.08746021669992432024 -47.00000000000000000000
+CurvePt 0 -0.56408546247762714199 -3.04824664209138251891 -47.00000000000000000000
+CurvePt 0 -0.85299046602062367217 -2.98033677037980071489 -47.00000000000000710543
+CurvePt 0 -1.14109359964178458391 -2.88234373329353799065 -47.00000000000000000000
+CurvePt 0 -1.42381323847358975954 -2.75368042117223810195 -47.00000000000000000000
+CurvePt 0 -1.69635023549392172093 -2.59468608477782503030 -47.00000000000000000000
+CurvePt 0 -1.95392419183759535883 -2.40669488148202059818 -47.00000000000000000000
+CurvePt 0 -2.19203102167827879043 -2.19203102167830499170 -47.00000000000000710543
+CurvePt 0 -2.40669488148199572919 -1.95392419183762333645 -47.00000000000000000000
+CurvePt 0 -2.59468608477780149357 -1.69635023549395103082 -47.00000000000000000000
+CurvePt 0 -2.75368042117221722975 -1.42381323847362017965 -47.00000000000000000000
+CurvePt 0 -2.88234373329351889481 -1.14109359964181567015 -47.00000000000000000000
+CurvePt 0 -2.98033677037978383950 -0.85299046602065575762 -47.00000000000000710543
+CurvePt 0 -3.04824664209136786397 -0.56408546247765944948 -47.00000000000000000000
+CurvePt 0 -3.08746021669991188574 -0.27854875748289548154 -47.00000000000000000000
+CurvePt 1 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000
+AddCurve
+Curve 00000017 1 1 00000009 00000009
+CCtrl 0 -3.09999999999998943068 -0.00000000000001134648 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999998898659 -0.00000000000001167955 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -3.09999999999998943068 -0.00000000000001134648 -47.00000000000000000000
+CurvePt 1 -4.59999999999998898659 -0.00000000000001167955 -47.00000000000000000000
+AddCurve
+Curve 00000018 1 2 00000009 00000008
+CCtrl 0 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.09999999999999964473 3.09999999999998809841 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000098133 3.10000000000000008882 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -3.09999999999998943068 -0.00000000000001122760 -47.00000000000000000000
+CurvePt 0 -3.08746021669991366210 0.27854875748287311055 -47.00000000000000000000
+CurvePt 0 -3.04824664209137230486 0.56408546247763746706 -47.00000000000000000000
+CurvePt 0 -2.98033677037978961266 0.85299046602063421929 -47.00000000000000710543
+CurvePt 0 -2.88234373329352733251 1.14109359964179502001 -47.00000000000000000000
+CurvePt 0 -2.75368042117222744380 1.42381323847360019563 -47.00000000000000000000
+CurvePt 0 -2.59468608477781392807 1.69635023549393215703 -47.00000000000000000000
+CurvePt 0 -2.40669488148200949595 1.95392419183760557289 -47.00000000000000000000
+CurvePt 0 -2.19203102167829433355 2.19203102167828900448 -47.00000000000000710543
+CurvePt 0 -1.95392419183761267831 2.40669488148200638733 -47.00000000000000000000
+CurvePt 0 -1.69635023549394037268 2.59468608477781259580 -47.00000000000000000000
+CurvePt 0 -1.42381323847360974355 2.75368042117222788789 -47.00000000000000000000
+CurvePt 0 -1.14109359964180523406 2.88234373329352999704 -47.00000000000000000000
+CurvePt 0 -0.85299046602064543254 2.98033677037979449764 -47.00000000000000710543
+CurvePt 0 -0.56408546247764912440 3.04824664209137852211 -47.00000000000000000000
+CurvePt 0 -0.27854875748288526749 3.08746021669992254388 -47.00000000000000000000
+CurvePt 1 -0.00000000000000098133 3.10000000000000008882 -47.00000000000000000000
+AddCurve
+Curve 00000019 1 1 0000000a 0000000d
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000
+AddCurve
+Curve 0000001a 1 2 0000000a 00000009
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.59999999999999875655 4.60000000000000941469 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -47.00000000000000000000
+CurvePt 0 0.41333041432944106486 4.58139257961924162288 -47.00000000000000000000
+CurvePt 0 0.62419880217413448165 4.55745278147392163248 -47.00000000000000000000
+CurvePt 0 0.83703004109586542913 4.52320469471624342361 -47.00000000000000000000
+CurvePt 0 1.05112374706965194804 4.47829642479662926036 -47.00000000000000000000
+CurvePt 0 1.26572778828869925150 4.42243520766034681202 -47.00000000000000710543
+CurvePt 0 1.48004406469028371163 4.35539545467172128923 -46.99999999999999289457
+CurvePt 0 1.69323566398461511362 4.27702618488718311340 -47.00000000000000000000
+CurvePt 0 1.90443533046029278566 4.18725758368106948382 -47.00000000000000000000
+CurvePt 0 2.11275512805761600532 4.08610643141686669111 -47.00000000000000000000
+CurvePt 0 2.31729712386809705293 3.97368016323818995517 -46.99999999999999289457
+CurvePt 0 2.51716486557165719518 3.85017935160580071496 -47.00000000000000000000
+CurvePt 0 2.71147537980488939624 3.71589844650146261529 -47.00000000000000000000
+CurvePt 0 2.89937138143646233601 3.57122466284428430328 -47.00000000000000000000
+CurvePt 0 3.08003335920409426762 3.41663496823848644723 -47.00000000000000710543
+CurvePt 0 3.25269119345812152133 3.25269119345812596222 -47.00000000000000710543
+CurvePt 0 3.41663496823848289452 3.08003335920410004078 -47.00000000000000710543
+CurvePt 0 3.57122466284428163874 2.89937138143646810917 -47.00000000000000000000
+CurvePt 0 3.71589844650146128302 2.71147537980489605758 -47.00000000000000000000
+CurvePt 0 3.85017935160579982679 2.51716486557166430060 -47.00000000000000000000
+CurvePt 0 3.97368016323818951108 2.31729712386810504654 -46.99999999999999289457
+CurvePt 0 4.08610643141686757929 2.11275512805762444302 -47.00000000000000000000
+CurvePt 0 4.18725758368107126017 1.90443533046030188949 -47.00000000000000000000
+CurvePt 0 4.27702618488718577794 1.69323566398462443949 -47.00000000000000000000
+CurvePt 0 4.35539545467172484194 1.48004406469029348159 -46.99999999999999289457
+CurvePt 0 4.42243520766035302927 1.26572778828870946555 -47.00000000000000710543
+CurvePt 0 4.47829642479663458943 1.05112374706966260618 -47.00000000000000000000
+CurvePt 0 4.52320469471625141722 0.83703004109587619830 -47.00000000000000000000
+CurvePt 0 4.55745278147392873791 0.62419880217414547285 -47.00000000000000000000
+CurvePt 0 4.58139257961925050466 0.41333041432945211158 -47.00000000000000000000
+CurvePt 1 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000
+AddCurve
+Curve 0000001b 1 1 0000000b 0000000a
+CCtrl 0 4.60000000000001030287 0.00000000000001167955 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000000941469 0.00000000000001101341 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000001030287 0.00000000000001167955 -47.00000000000000000000
+CurvePt 1 4.60000000000000941469 0.00000000000001101341 -44.00000000000000000000
+AddCurve
+Curve 0000001c 1 2 0000000b 00000009
+CCtrl 0 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000002007283 -4.59999999999998809841 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000001030287 0.00000000000001093981 -47.00000000000000000000
+CurvePt 0 4.58139257961925228102 -0.41333041432943040672 -47.00000000000000000000
+CurvePt 0 4.55745278147393140245 -0.62419880217412382351 -47.00000000000000000000
+CurvePt 0 4.52320469471625408175 -0.83703004109585488202 -47.00000000000000000000
+CurvePt 0 4.47829642479664080668 -1.05112374706964128990 -47.00000000000000000000
+CurvePt 0 4.42243520766035835834 -1.26572778828868837131 -47.00000000000000710543
+CurvePt 0 4.35539545467173105919 -1.48004406469027327553 -46.99999999999999289457
+CurvePt 0 4.27702618488719377154 -1.69323566398460401139 -47.00000000000000000000
+CurvePt 0 4.18725758368108014196 -1.90443533046028234956 -47.00000000000000000000
+CurvePt 0 4.08610643141687734925 -2.11275512805760534718 -47.00000000000000000000
+CurvePt 0 3.97368016323820061331 -2.31729712386808639479 -46.99999999999999289457
+CurvePt 0 3.85017935160581137310 -2.51716486557164609295 -47.00000000000000000000
+CurvePt 0 3.71589844650147371752 -2.71147537980487829401 -47.00000000000000000000
+CurvePt 0 3.57122466284429496142 -2.89937138143645123378 -47.00000000000000000000
+CurvePt 0 3.41663496823849799355 -3.08003335920408405357 -47.00000000000000710543
+CurvePt 0 3.25269119345813617628 -3.25269119345811086319 -47.00000000000000710543
+CurvePt 0 3.08003335920411025484 -3.41663496823847268047 -47.00000000000000710543
+CurvePt 0 2.89937138143647876731 -3.57122466284427142469 -47.00000000000000000000
+CurvePt 0 2.71147537980490627163 -3.71589844650145018079 -47.00000000000000000000
+CurvePt 0 2.51716486557167495874 -3.85017935160578961273 -47.00000000000000000000
+CurvePt 0 2.31729712386811526059 -3.97368016323817929702 -46.99999999999999289457
+CurvePt 0 2.11275512805763554525 -4.08610643141685692115 -47.00000000000000000000
+CurvePt 0 1.90443533046031276967 -4.18725758368106060203 -47.00000000000000000000
+CurvePt 0 1.69323566398463531968 -4.27702618488717511980 -47.00000000000000000000
+CurvePt 0 1.48004406469030458382 -4.35539545467171418380 -46.99999999999999289457
+CurvePt 0 1.26572778828872012369 -4.42243520766034237113 -47.00000000000000710543
+CurvePt 0 1.05112374706967326432 -4.47829642479662393129 -47.00000000000000000000
+CurvePt 0 0.83703004109588685644 -4.52320469471623987090 -47.00000000000000000000
+CurvePt 0 0.62419880217415613100 -4.55745278147391896795 -47.00000000000000000000
+CurvePt 0 0.41333041432946288074 -4.58139257961923984652 -47.00000000000000000000
+CurvePt 1 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000
+AddCurve
+Curve 0000001d 1 1 0000000c 0000000b
+CCtrl 0 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000
+CurvePt 1 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+AddCurve
+Curve 0000001e 1 2 0000000c 00000009
+CCtrl 0 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999997744027 -4.60000000000001030287 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000002165757 -4.59999999999999964473 -47.00000000000000000000
+CurvePt 0 -0.41333041432941969306 -4.58139257961924162288 -47.00000000000000000000
+CurvePt 0 -0.62419880217411316536 -4.55745278147392252066 -47.00000000000000000000
+CurvePt 0 -0.83703004109584400183 -4.52320469471624342361 -47.00000000000000000000
+CurvePt 0 -1.05112374706963063176 -4.47829642479662926036 -47.00000000000000000000
+CurvePt 0 -1.26572778828867771317 -4.42243520766034681202 -47.00000000000000710543
+CurvePt 0 -1.48004406469026217330 -4.35539545467172128923 -46.99999999999999289457
+CurvePt 0 -1.69323566398459357529 -4.27702618488718311340 -47.00000000000000000000
+CurvePt 0 -1.90443533046027169142 -4.18725758368106948382 -47.00000000000000000000
+CurvePt 0 -2.11275512805759468904 -4.08610643141686757929 -47.00000000000000000000
+CurvePt 0 -2.31729712386807573665 -3.97368016323818995517 -46.99999999999999289457
+CurvePt 0 -2.51716486557163543480 -3.85017935160580160314 -47.00000000000000000000
+CurvePt 0 -2.71147537980486763587 -3.71589844650146305938 -47.00000000000000000000
+CurvePt 0 -2.89937138143644057564 -3.57122466284428563554 -47.00000000000000000000
+CurvePt 0 -3.08003335920407295134 -3.41663496823848777950 -47.00000000000000710543
+CurvePt 0 -3.25269119345809976096 -3.25269119345812596222 -47.00000000000000710543
+CurvePt 0 -3.41663496823846202233 -3.08003335920410004078 -47.00000000000000710543
+CurvePt 0 -3.57122466284425987837 -2.89937138143646855326 -47.00000000000000000000
+CurvePt 0 -3.71589844650143952265 -2.71147537980489650167 -47.00000000000000000000
+CurvePt 0 -3.85017935160577851050 -2.51716486557166474469 -47.00000000000000000000
+CurvePt 0 -3.97368016323816775071 -2.31729712386810504654 -46.99999999999999289457
+CurvePt 0 -4.08610643141684626301 -2.11275512805762488711 -47.00000000000000000000
+CurvePt 0 -4.18725758368104994389 -1.90443533046030255562 -47.00000000000000000000
+CurvePt 0 -4.27702618488716446166 -1.69323566398462532767 -47.00000000000000000000
+CurvePt 0 -4.35539545467170352566 -1.48004406469029459181 -46.99999999999999289457
+CurvePt 0 -4.42243520766033171299 -1.26572778828870990964 -47.00000000000000710543
+CurvePt 0 -4.47829642479661416132 -1.05112374706966305027 -47.00000000000000000000
+CurvePt 0 -4.52320469471622921276 -0.83703004109587675341 -47.00000000000000000000
+CurvePt 0 -4.55745278147390830981 -0.62419880217414602797 -47.00000000000000000000
+CurvePt 0 -4.58139257961922918838 -0.41333041432945266669 -47.00000000000000000000
+CurvePt 1 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000
+AddCurve
+Curve 0000001f 1 1 0000000d 0000000c
+CCtrl 0 -4.59999999999998898659 -0.00000000000001167955 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999998987477 -0.00000000000001101341 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999998898659 -0.00000000000001167955 -47.00000000000000000000
+CurvePt 1 -4.59999999999998987477 -0.00000000000001101341 -44.00000000000000000000
+AddCurve
+Curve 00000020 1 2 0000000d 00000009
+CCtrl 0 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.60000000000000053291 4.59999999999998721023 -47.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000134872 4.59999999999999964473 -47.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999998898659 -0.00000000000001150315 -47.00000000000000000000
+CurvePt 0 -4.58139257961923185292 0.41333041432942979609 -47.00000000000000000000
+CurvePt 0 -4.55745278147391097434 0.62419880217412326839 -47.00000000000000000000
+CurvePt 0 -4.52320469471623276547 0.83703004109585421588 -47.00000000000000000000
+CurvePt 0 -4.47829642479661949039 1.05112374706964062376 -47.00000000000000000000
+CurvePt 0 -4.42243520766033704206 1.26572778828868792722 -47.00000000000000710543
+CurvePt 0 -4.35539545467171063109 1.48004406469027238735 -46.99999999999999289457
+CurvePt 0 -4.27702618488717245526 1.69323566398460356730 -47.00000000000000000000
+CurvePt 0 -4.18725758368105882568 1.90443533046028168343 -47.00000000000000000000
+CurvePt 0 -4.08610643141685692115 2.11275512805760490309 -47.00000000000000000000
+CurvePt 0 -3.97368016323817929702 2.31729712386808506253 -46.99999999999999289457
+CurvePt 0 -3.85017935160579138909 2.51716486557164564886 -47.00000000000000000000
+CurvePt 0 -3.71589844650145328941 2.71147537980487784992 -47.00000000000000000000
+CurvePt 0 -3.57122466284427497740 2.89937138143645123378 -47.00000000000000000000
+CurvePt 0 -3.41663496823847712136 3.08003335920408272131 -47.00000000000000710543
+CurvePt 0 -3.25269119345811619226 3.25269119345810997501 -47.00000000000000710543
+CurvePt 0 -3.08003335920409027082 3.41663496823847179229 -47.00000000000000710543
+CurvePt 0 -2.89937138143645878330 3.57122466284427053651 -47.00000000000000000000
+CurvePt 0 -2.71147537980488628762 3.71589844650144973670 -47.00000000000000000000
+CurvePt 0 -2.51716486557165453064 3.85017935160578872456 -47.00000000000000000000
+CurvePt 0 -2.31729712386809483249 3.97368016323817796476 -46.99999999999999289457
+CurvePt 0 -2.11275512805761511714 4.08610643141685692115 -47.00000000000000000000
+CurvePt 0 -1.90443533046029256361 4.18725758368106060203 -47.00000000000000000000
+CurvePt 0 -1.69323566398461489158 4.27702618488717511980 -47.00000000000000000000
+CurvePt 0 -1.48004406469028415572 4.35539545467171418380 -46.99999999999999289457
+CurvePt 0 -1.26572778828869991763 4.42243520766034148295 -47.00000000000000710543
+CurvePt 0 -1.05112374706965305826 4.47829642479662393129 -47.00000000000000000000
+CurvePt 0 -0.83703004109586653936 4.52320469471623987090 -47.00000000000000000000
+CurvePt 0 -0.62419880217413592494 4.55745278147391896795 -47.00000000000000000000
+CurvePt 0 -0.41333041432944261917 4.58139257961923984652 -47.00000000000000000000
+CurvePt 1 -0.00000000000000134872 4.59999999999999964473 -47.00000000000000000000
+AddCurve
+Curve 00000021 1 1 0000000e 00000011
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000
+AddCurve
+Curve 00000022 1 2 0000000e 0000000a
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.59999999999999875655 4.60000000000000941469 -44.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -44.00000000000000000000
+CurvePt 0 0.41333041432944106486 4.58139257961924162288 -43.99999999999999289457
+CurvePt 0 0.62419880217413448165 4.55745278147392163248 -44.00000000000000000000
+CurvePt 0 0.83703004109586542913 4.52320469471624342361 -44.00000000000000000000
+CurvePt 0 1.05112374706965194804 4.47829642479662926036 -44.00000000000000000000
+CurvePt 0 1.26572778828869925150 4.42243520766034681202 -44.00000000000000000000
+CurvePt 0 1.48004406469028371163 4.35539545467172128923 -44.00000000000000000000
+CurvePt 0 1.69323566398461489158 4.27702618488718222522 -44.00000000000000000000
+CurvePt 0 1.90443533046029278566 4.18725758368106948382 -43.99999999999999289457
+CurvePt 0 2.11275512805761600532 4.08610643141686669111 -43.99999999999999289457
+CurvePt 0 2.31729712386809705293 3.97368016323818995517 -43.99999999999999289457
+CurvePt 0 2.51716486557165630700 3.85017935160580071496 -44.00000000000000000000
+CurvePt 0 2.71147537980488850806 3.71589844650146261529 -44.00000000000000710543
+CurvePt 0 2.89937138143646189192 3.57122466284428385919 -44.00000000000000000000
+CurvePt 0 3.08003335920409426762 3.41663496823848644723 -44.00000000000000710543
+CurvePt 0 3.25269119345812107724 3.25269119345812596222 -44.00000000000000000000
+CurvePt 0 3.41663496823848289452 3.08003335920410004078 -44.00000000000000710543
+CurvePt 0 3.57122466284428163874 2.89937138143646766508 -44.00000000000000000000
+CurvePt 0 3.71589844650145995075 2.71147537980489561349 -44.00000000000000710543
+CurvePt 0 3.85017935160579982679 2.51716486557166385651 -44.00000000000000000000
+CurvePt 0 3.97368016323818951108 2.31729712386810460245 -43.99999999999999289457
+CurvePt 0 4.08610643141686757929 2.11275512805762444302 -43.99999999999999289457
+CurvePt 0 4.18725758368107037199 1.90443533046030166744 -43.99999999999999289457
+CurvePt 0 4.27702618488718488976 1.69323566398462399540 -44.00000000000000000000
+CurvePt 0 4.35539545467172484194 1.48004406469029303750 -44.00000000000000000000
+CurvePt 0 4.42243520766035214109 1.26572778828870879941 -44.00000000000000000000
+CurvePt 0 4.47829642479663458943 1.05112374706966194005 -44.00000000000000000000
+CurvePt 0 4.52320469471624964086 0.83703004109587575421 -44.00000000000000000000
+CurvePt 0 4.55745278147392873791 0.62419880217414491774 -44.00000000000000000000
+CurvePt 0 4.58139257961924961648 0.41333041432945155647 -43.99999999999999289457
+CurvePt 1 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000
+AddCurve
+Curve 00000023 1 1 0000000f 0000000e
+CCtrl 0 4.60000000000000941469 0.00000000000001101341 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.85000000000000985878 0.00000000000001068035 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000000941469 0.00000000000001101341 -44.00000000000000000000
+CurvePt 1 3.85000000000000985878 0.00000000000001068035 -43.25000000000000000000
+AddCurve
+Curve 00000024 1 2 0000000f 0000000b
+CCtrl 0 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000001918465 -4.59999999999998809841 -44.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000000941469 0.00000000000001027368 -44.00000000000000000000
+CurvePt 0 4.58139257961925139284 -0.41333041432943096183 -43.99999999999999289457
+CurvePt 0 4.55745278147393140245 -0.62419880217412448964 -44.00000000000000000000
+CurvePt 0 4.52320469471625319358 -0.83703004109585532611 -44.00000000000000000000
+CurvePt 0 4.47829642479663991850 -1.05112374706964173399 -44.00000000000000000000
+CurvePt 0 4.42243520766035747016 -1.26572778828868881540 -44.00000000000000000000
+CurvePt 0 4.35539545467173105919 -1.48004406469027371962 -44.00000000000000000000
+CurvePt 0 4.27702618488719288337 -1.69323566398460445548 -44.00000000000000000000
+CurvePt 0 4.18725758368107925378 -1.90443533046028279365 -43.99999999999999289457
+CurvePt 0 4.08610643141687646107 -2.11275512805760579127 -43.99999999999999289457
+CurvePt 0 3.97368016323819928104 -2.31729712386808639479 -43.99999999999999289457
+CurvePt 0 3.85017935160581048493 -2.51716486557164609295 -44.00000000000000000000
+CurvePt 0 3.71589844650147238525 -2.71147537980487873810 -44.00000000000000710543
+CurvePt 0 3.57122466284429496142 -2.89937138143645167787 -44.00000000000000000000
+CurvePt 0 3.41663496823849666129 -3.08003335920408405357 -44.00000000000000710543
+CurvePt 0 3.25269119345813528810 -3.25269119345811086319 -44.00000000000000000000
+CurvePt 0 3.08003335920410936666 -3.41663496823847268047 -44.00000000000000710543
+CurvePt 0 2.89937138143647743505 -3.57122466284427142469 -44.00000000000000000000
+CurvePt 0 2.71147537980490538345 -3.71589844650145018079 -44.00000000000000710543
+CurvePt 0 2.51716486557167362648 -3.85017935160578961273 -44.00000000000000000000
+CurvePt 0 2.31729712386811437241 -3.97368016323817929702 -43.99999999999999289457
+CurvePt 0 2.11275512805763421298 -4.08610643141685692115 -43.99999999999999289457
+CurvePt 0 1.90443533046031165945 -4.18725758368106060203 -43.99999999999999289457
+CurvePt 0 1.69323566398463376537 -4.27702618488717511980 -44.00000000000000000000
+CurvePt 0 1.48004406469030347360 -4.35539545467171418380 -44.00000000000000000000
+CurvePt 0 1.26572778828871856938 -4.42243520766034237113 -44.00000000000000000000
+CurvePt 0 1.05112374706967193205 -4.47829642479662393129 -44.00000000000000000000
+CurvePt 0 0.83703004109588552417 -4.52320469471623987090 -44.00000000000000000000
+CurvePt 0 0.62419880217415479873 -4.55745278147391896795 -44.00000000000000000000
+CurvePt 0 0.41333041432946154847 -4.58139257961923984652 -43.99999999999999289457
+CurvePt 1 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+AddCurve
+Curve 00000025 1 1 00000010 0000000f
+CCtrl 0 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+CurvePt 1 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+AddCurve
+Curve 00000026 1 2 00000010 0000000c
+CCtrl 0 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999997832845 -4.60000000000000941469 -44.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000002032531 -4.59999999999999964473 -44.00000000000000000000
+CurvePt 0 -0.41333041432942096982 -4.58139257961924162288 -43.99999999999999289457
+CurvePt 0 -0.62419880217411438661 -4.55745278147392163248 -44.00000000000000000000
+CurvePt 0 -0.83703004109584522308 -4.52320469471624342361 -44.00000000000000000000
+CurvePt 0 -1.05112374706963196402 -4.47829642479662926036 -44.00000000000000000000
+CurvePt 0 -1.26572778828867882339 -4.42243520766034681202 -44.00000000000000000000
+CurvePt 0 -1.48004406469026350557 -4.35539545467172128923 -44.00000000000000000000
+CurvePt 0 -1.69323566398459512961 -4.27702618488718311340 -44.00000000000000000000
+CurvePt 0 -1.90443533046027280164 -4.18725758368106948382 -43.99999999999999289457
+CurvePt 0 -2.11275512805759557722 -4.08610643141686669111 -43.99999999999999289457
+CurvePt 0 -2.31729712386807706892 -3.97368016323818995517 -43.99999999999999289457
+CurvePt 0 -2.51716486557163632298 -3.85017935160580071496 -44.00000000000000000000
+CurvePt 0 -2.71147537980486896814 -3.71589844650146261529 -44.00000000000000710543
+CurvePt 0 -2.89937138143644190791 -3.57122466284428430328 -44.00000000000000000000
+CurvePt 0 -3.08003335920407383952 -3.41663496823848644723 -44.00000000000000710543
+CurvePt 0 -3.25269119345810064914 -3.25269119345812596222 -44.00000000000000000000
+CurvePt 0 -3.41663496823846335460 -3.08003335920410004078 -44.00000000000000710543
+CurvePt 0 -3.57122466284426121064 -2.89937138143646810917 -44.00000000000000000000
+CurvePt 0 -3.71589844650144041083 -2.71147537980489605758 -44.00000000000000710543
+CurvePt 0 -3.85017935160577895459 -2.51716486557166430060 -44.00000000000000000000
+CurvePt 0 -3.97368016323816908297 -2.31729712386810504654 -43.99999999999999289457
+CurvePt 0 -4.08610643141684715118 -2.11275512805762444302 -43.99999999999999289457
+CurvePt 0 -4.18725758368105083207 -1.90443533046030188949 -43.99999999999999289457
+CurvePt 0 -4.27702618488716534983 -1.69323566398462421745 -44.00000000000000000000
+CurvePt 0 -4.35539545467170441384 -1.48004406469029348159 -44.00000000000000000000
+CurvePt 0 -4.42243520766033171299 -1.26572778828870924350 -44.00000000000000000000
+CurvePt 0 -4.47829642479661504950 -1.05112374706966238413 -44.00000000000000000000
+CurvePt 0 -4.52320469471623010094 -0.83703004109587619830 -44.00000000000000000000
+CurvePt 0 -4.55745278147390830981 -0.62419880217414536183 -44.00000000000000000000
+CurvePt 0 -4.58139257961923007656 -0.41333041432945205607 -43.99999999999999289457
+CurvePt 1 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000
+AddCurve
+Curve 00000027 1 1 00000011 00000010
+CCtrl 0 -4.59999999999998987477 -0.00000000000001101341 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.84999999999999031886 -0.00000000000001068035 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999998987477 -0.00000000000001101341 -44.00000000000000000000
+CurvePt 1 -3.84999999999999031886 -0.00000000000001068035 -43.25000000000000000000
+AddCurve
+Curve 00000028 1 2 00000011 0000000d
+CCtrl 0 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.60000000000000053291 4.59999999999998809841 -44.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999998987477 -0.00000000000001083701 -44.00000000000000000000
+CurvePt 0 -4.58139257961923274109 0.41333041432943046223 -43.99999999999999289457
+CurvePt 0 -4.55745278147391186252 0.62419880217412393453 -44.00000000000000000000
+CurvePt 0 -4.52320469471623365365 0.83703004109585488202 -44.00000000000000000000
+CurvePt 0 -4.47829642479662037857 1.05112374706964151194 -44.00000000000000000000
+CurvePt 0 -4.42243520766033793024 1.26572778828868859335 -44.00000000000000000000
+CurvePt 0 -4.35539545467171151927 1.48004406469027327553 -44.00000000000000000000
+CurvePt 0 -4.27702618488717334344 1.69323566398460445548 -44.00000000000000000000
+CurvePt 0 -4.18725758368105971385 1.90443533046028234956 -43.99999999999999289457
+CurvePt 0 -4.08610643141685692115 2.11275512805760534718 -43.99999999999999289457
+CurvePt 0 -3.97368016323818018520 2.31729712386808639479 -43.99999999999999289457
+CurvePt 0 -3.85017935160579138909 2.51716486557164609295 -44.00000000000000000000
+CurvePt 0 -3.71589844650145328941 2.71147537980487829401 -44.00000000000000710543
+CurvePt 0 -3.57122466284427542149 2.89937138143645167787 -44.00000000000000000000
+CurvePt 0 -3.41663496823847756545 3.08003335920408405357 -44.00000000000000710543
+CurvePt 0 -3.25269119345811708044 3.25269119345811086319 -44.00000000000000000000
+CurvePt 0 -3.08003335920409071491 3.41663496823847268047 -44.00000000000000710543
+CurvePt 0 -2.89937138143645878330 3.57122466284427142469 -44.00000000000000000000
+CurvePt 0 -2.71147537980488628762 3.71589844650145018079 -44.00000000000000710543
+CurvePt 0 -2.51716486557165453064 3.85017935160578961273 -44.00000000000000000000
+CurvePt 0 -2.31729712386809483249 3.97368016323817929702 -43.99999999999999289457
+CurvePt 0 -2.11275512805761511714 4.08610643141685692115 -43.99999999999999289457
+CurvePt 0 -1.90443533046029278566 4.18725758368106060203 -43.99999999999999289457
+CurvePt 0 -1.69323566398461511362 4.27702618488717511980 -44.00000000000000000000
+CurvePt 0 -1.48004406469028415572 4.35539545467171418380 -44.00000000000000000000
+CurvePt 0 -1.26572778828869991763 4.42243520766034237113 -44.00000000000000000000
+CurvePt 0 -1.05112374706965305826 4.47829642479662393129 -44.00000000000000000000
+CurvePt 0 -0.83703004109586653936 4.52320469471623987090 -44.00000000000000000000
+CurvePt 0 -0.62419880217413592494 4.55745278147391896795 -44.00000000000000000000
+CurvePt 0 -0.41333041432944261917 4.58139257961923984652 -43.99999999999999289457
+CurvePt 1 -0.00000000000000134872 4.59999999999999964473 -44.00000000000000000000
+AddCurve
+Curve 00000029 1 1 00000012 00000015
+CCtrl 0 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000
+AddCurve
+Curve 0000002a 1 2 00000012 0000000e
+CCtrl 0 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.84999999999999920064 3.85000000000000941469 -43.25000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 3.85000000000000008882 -43.25000000000000000000
+CurvePt 0 0.34593958590616263882 3.83442639815958319360 -43.24999999999999289457
+CurvePt 0 0.70055775178675694370 3.78572566840381297126 -43.25000000000000000000
+CurvePt 0 1.05935912715467228651 3.70138598902007398550 -43.25000000000000000000
+CurvePt 0 1.41716463181321050691 3.57968495909035988589 -43.25000000000000000000
+CurvePt 0 1.59392957005915847368 3.50455254286350470494 -43.24999999999999289457
+CurvePt 0 1.76828418326561376261 3.41989342629455261857 -43.24999999999999289457
+CurvePt 0 1.93947694062873354781 3.32579752792761640379 -43.24999999999999289457
+CurvePt 0 2.10675755053280022722 3.22243271819181265059 -43.25000000000000000000
+CurvePt 0 2.26938700266278781115 3.11004543891970364200 -43.25000000000000710543
+CurvePt 0 2.42664778663703950556 2.98895977216315200664 -43.25000000000000000000
+CurvePt 0 2.57785400715994894583 2.85957491906916949631 -43.25000000000000710543
+CurvePt 0 2.72236110756821059198 2.72236110756821503287 -43.25000000000000710543
+CurvePt 0 2.85957491906916594360 2.57785400715995383081 -43.25000000000000710543
+CurvePt 0 2.98895977216314978619 2.42664778663704527872 -43.25000000000000000000
+CurvePt 0 3.11004543891970097746 2.26938700266279402840 -43.25000000000000710543
+CurvePt 0 3.22243271819181131832 2.10675755053280688855 -43.25000000000000000000
+CurvePt 0 3.32579752792761595970 1.93947694062874131937 -43.24999999999999289457
+CurvePt 0 3.41989342629455306266 1.76828418326562175622 -43.24999999999999289457
+CurvePt 0 3.50455254286350603721 1.59392957005916668933 -43.24999999999999289457
+CurvePt 0 3.57968495909036299452 1.41716463181321938869 -43.25000000000000000000
+CurvePt 0 3.70138598902007842639 1.05935912715468183443 -43.25000000000000000000
+CurvePt 0 3.78572566840381918851 0.70055775178676693571 -43.25000000000000000000
+CurvePt 0 3.83442639815959207539 0.34593958590617285287 -43.24999999999999289457
+CurvePt 1 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000
+AddCurve
+Curve 0000002b 1 1 00000013 00000012
+CCtrl 0 3.85000000000000985878 0.00000000000001068035 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000000941469 0.00000000000001068035 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 3.85000000000000985878 0.00000000000001068035 -43.25000000000000000000
+CurvePt 1 4.60000000000000941469 0.00000000000001068035 -42.50000000000000000000
+AddCurve
+Curve 0000002c 1 2 00000013 0000000f
+CCtrl 0 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 3.85000000000001918465 -3.84999999999998898659 -43.25000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 3.85000000000000985878 0.00000000000001006122 -43.25000000000000000000
+CurvePt 0 3.83442639815959340766 -0.34593958590615275783 -43.24999999999999289457
+CurvePt 0 3.78572566840382362940 -0.70055775178674717374 -43.25000000000000000000
+CurvePt 0 3.70138598902008419955 -1.05935912715466229450 -43.25000000000000000000
+CurvePt 0 3.57968495909037054403 -1.41716463181320073694 -43.25000000000000000000
+CurvePt 0 3.50455254286351447490 -1.59392957005914870372 -43.24999999999999289457
+CurvePt 0 3.41989342629456194445 -1.76828418326560377061 -43.24999999999999289457
+CurvePt 0 3.32579752792762617375 -1.93947694062872333376 -43.24999999999999289457
+CurvePt 0 3.22243271819182242055 -2.10675755053278956908 -43.25000000000000000000
+CurvePt 0 3.11004543891971296787 -2.26938700266277759710 -43.25000000000000710543
+CurvePt 0 2.98895977216316222069 -2.42664778663702973560 -43.25000000000000000000
+CurvePt 0 2.85957491906917926627 -2.57785400715993917586 -43.25000000000000710543
+CurvePt 0 2.72236110756822435874 -2.72236110756820082202 -43.25000000000000710543
+CurvePt 0 2.57785400715996404486 -2.85957491906915572955 -43.25000000000000710543
+CurvePt 0 2.42664778663705460460 -2.98895977216313957214 -43.25000000000000000000
+CurvePt 0 2.26938700266280424245 -3.11004543891969165159 -43.25000000000000710543
+CurvePt 0 2.10675755053281665852 -3.22243271819180154836 -43.25000000000000000000
+CurvePt 0 1.93947694062875086729 -3.32579752792760618973 -43.24999999999999289457
+CurvePt 0 1.76828418326563130414 -3.41989342629454329270 -43.24999999999999289457
+CurvePt 0 1.59392957005917668134 -3.50455254286349582316 -43.24999999999999289457
+CurvePt 0 1.41716463181322915865 -3.57968495909035233637 -43.25000000000000000000
+CurvePt 0 1.05935912715469160439 -3.70138598902006821234 -43.25000000000000000000
+CurvePt 0 0.70055775178677670567 -3.78572566840380986264 -43.25000000000000000000
+CurvePt 0 0.34593958590618267834 -3.83442639815958141725 -43.24999999999999289457
+CurvePt 1 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+AddCurve
+Curve 0000002d 1 1 00000014 00000013
+CCtrl 0 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+CurvePt 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+AddCurve
+Curve 0000002e 1 2 00000014 00000010
+CCtrl 0 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.84999999999997877254 -3.85000000000000985878 -43.25000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000001990039 -3.85000000000000008882 -43.25000000000000000000
+CurvePt 0 -0.34593958590614293236 -3.83442639815958363769 -43.24999999999999289457
+CurvePt 0 -0.70055775178673729275 -3.78572566840381297126 -43.25000000000000000000
+CurvePt 0 -1.05935912715465230249 -3.70138598902007398550 -43.25000000000000000000
+CurvePt 0 -1.41716463181319074494 -3.57968495909035988589 -43.25000000000000000000
+CurvePt 0 -1.59392957005913871171 -3.50455254286350470494 -43.24999999999999289457
+CurvePt 0 -1.76828418326559400064 -3.41989342629455261857 -43.24999999999999289457
+CurvePt 0 -1.93947694062871334175 -3.32579752792761684788 -43.24999999999999289457
+CurvePt 0 -2.10675755053277979911 -3.22243271819181265059 -43.25000000000000000000
+CurvePt 0 -2.26938700266276782713 -3.11004543891970364200 -43.25000000000000710543
+CurvePt 0 -2.42664778663701952155 -2.98895977216315289482 -43.25000000000000000000
+CurvePt 0 -2.57785400715992896181 -2.85957491906916994040 -43.25000000000000710543
+CurvePt 0 -2.72236110756819060796 -2.72236110756821503287 -43.25000000000000710543
+CurvePt 0 -2.85957491906914551549 -2.57785400715995427490 -43.25000000000000710543
+CurvePt 0 -2.98895977216312980218 -2.42664778663704572281 -43.25000000000000000000
+CurvePt 0 -3.11004543891968143754 -2.26938700266279447249 -43.25000000000000710543
+CurvePt 0 -3.22243271819179133431 -2.10675755053280733264 -43.25000000000000000000
+CurvePt 0 -3.32579752792759597568 -1.93947694062874131937 -43.24999999999999289457
+CurvePt 0 -3.41989342629453307865 -1.76828418326562197826 -43.24999999999999289457
+CurvePt 0 -3.50455254286348649728 -1.59392957005916779956 -43.24999999999999289457
+CurvePt 0 -3.57968495909034256641 -1.41716463181321983278 -43.25000000000000000000
+CurvePt 0 -3.70138598902005888647 -1.05935912715468227852 -43.25000000000000000000
+CurvePt 0 -3.78572566840379964859 -0.70055775178676749082 -43.25000000000000000000
+CurvePt 0 -3.83442639815957209137 -0.34593958590617335247 -43.24999999999999289457
+CurvePt 1 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000
+AddCurve
+Curve 0000002f 1 1 00000015 00000014
+CCtrl 0 -3.84999999999999031886 -0.00000000000001068035 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999998987477 -0.00000000000001068035 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -3.84999999999999031886 -0.00000000000001068035 -43.25000000000000000000
+CurvePt 1 -4.59999999999998987477 -0.00000000000001068035 -42.50000000000000000000
+AddCurve
+Curve 00000030 1 2 00000015 00000011
+CCtrl 0 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -3.85000000000000053291 3.84999999999998854250 -43.25000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -3.84999999999999031886 -0.00000000000001053271 -43.25000000000000000000
+CurvePt 0 -3.83442639815957386773 0.34593958590615231374 -43.24999999999999289457
+CurvePt 0 -3.78572566840380364539 0.70055775178674661863 -43.25000000000000000000
+CurvePt 0 -3.70138598902006465963 1.05935912715466185041 -43.25000000000000000000
+CurvePt 0 -3.57968495909035056002 1.41716463181320029285 -43.25000000000000000000
+CurvePt 0 -3.50455254286349493498 1.59392957005914781554 -43.24999999999999289457
+CurvePt 0 -3.41989342629454284861 1.76828418326560332652 -43.24999999999999289457
+CurvePt 0 -3.32579752792760663382 1.93947694062872333376 -43.24999999999999289457
+CurvePt 0 -3.22243271819180332471 2.10675755053278956908 -43.25000000000000000000
+CurvePt 0 -3.11004543891969387204 2.26938700266277759710 -43.25000000000000710543
+CurvePt 0 -2.98895977216314312486 2.42664778663702929151 -43.25000000000000000000
+CurvePt 0 -2.85957491906916061453 2.57785400715993873177 -43.25000000000000710543
+CurvePt 0 -2.72236110756820570700 2.72236110756819993384 -43.25000000000000710543
+CurvePt 0 -2.57785400715994494902 2.85957491906915572955 -43.25000000000000710543
+CurvePt 0 -2.42664778663703639694 2.98895977216313957214 -43.25000000000000000000
+CurvePt 0 -2.26938700266278514661 3.11004543891969120750 -43.25000000000000710543
+CurvePt 0 -2.10675755053279800677 3.22243271819180110427 -43.25000000000000000000
+CurvePt 0 -1.93947694062873177145 3.32579752792760574565 -43.24999999999999289457
+CurvePt 0 -1.76828418326561243035 3.41989342629454284861 -43.24999999999999289457
+CurvePt 0 -1.59392957005915802959 3.50455254286349537907 -43.24999999999999289457
+CurvePt 0 -1.41716463181321050691 3.57968495909035233637 -43.25000000000000000000
+CurvePt 0 -1.05935912715467295264 3.70138598902006821234 -43.25000000000000000000
+CurvePt 0 -0.70055775178675805392 3.78572566840380986264 -43.25000000000000000000
+CurvePt 0 -0.34593958590616397109 3.83442639815958141725 -43.24999999999999289457
+CurvePt 1 -0.00000000000000116502 3.85000000000000008882 -43.25000000000000000000
+AddCurve
+Curve 00000031 1 1 00000016 00000019
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000
+AddCurve
+Curve 00000032 1 2 00000016 00000012
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.59999999999999964473 4.60000000000000852651 -42.50000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -42.50000000000000000000
+CurvePt 0 0.41333041432944112037 4.58139257961924162288 -42.49999999999999289457
+CurvePt 0 0.62419880217413459267 4.55745278147392163248 -42.49999999999999289457
+CurvePt 0 0.83703004109586554016 4.52320469471624342361 -42.50000000000000000000
+CurvePt 0 1.05112374706965217008 4.47829642479662926036 -42.50000000000000710543
+CurvePt 0 1.26572778828869947354 4.42243520766034681202 -42.50000000000000710543
+CurvePt 0 1.48004406469028393367 4.35539545467172128923 -42.50000000000000000000
+CurvePt 0 1.69323566398461511362 4.27702618488718222522 -42.50000000000000000000
+CurvePt 0 1.90443533046029322975 4.18725758368106859564 -42.50000000000000000000
+CurvePt 0 2.11275512805761644941 4.08610643141686580293 -42.49999999999999289457
+CurvePt 0 2.31729712386809705293 3.97368016323818951108 -42.50000000000000000000
+CurvePt 0 2.51716486557165719518 3.85017935160580027087 -42.49999999999999289457
+CurvePt 0 2.71147537980488939624 3.71589844650146217120 -42.50000000000000710543
+CurvePt 0 2.89937138143646233601 3.57122466284428385919 -42.50000000000000000000
+CurvePt 0 3.08003335920409426762 3.41663496823848644723 -42.50000000000000710543
+CurvePt 0 3.25269119345812152133 3.25269119345812596222 -42.50000000000000000000
+CurvePt 0 3.41663496823848333861 3.08003335920409915261 -42.50000000000000710543
+CurvePt 0 3.57122466284428163874 2.89937138143646722099 -42.50000000000000000000
+CurvePt 0 3.71589844650146039484 2.71147537980489472531 -42.50000000000000710543
+CurvePt 0 3.85017935160579982679 2.51716486557166385651 -42.49999999999999289457
+CurvePt 0 3.97368016323818951108 2.31729712386810415836 -42.50000000000000000000
+CurvePt 0 4.08610643141686757929 2.11275512805762355484 -42.49999999999999289457
+CurvePt 0 4.18725758368107126017 1.90443533046030100131 -42.50000000000000000000
+CurvePt 0 4.27702618488718488976 1.69323566398462377336 -42.50000000000000000000
+CurvePt 0 4.35539545467172484194 1.48004406469029281546 -42.50000000000000000000
+CurvePt 0 4.42243520766035214109 1.26572778828870835532 -42.50000000000000710543
+CurvePt 0 4.47829642479663458943 1.05112374706966149596 -42.50000000000000710543
+CurvePt 0 4.52320469471624964086 0.83703004109587542114 -42.50000000000000000000
+CurvePt 0 4.55745278147392873791 0.62419880217414458468 -42.49999999999999289457
+CurvePt 0 4.58139257961924961648 0.41333041432945111238 -42.49999999999999289457
+CurvePt 1 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000
+AddCurve
+Curve 00000033 1 1 00000017 00000016
+CCtrl 0 4.60000000000000941469 0.00000000000001068035 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000000319744 0.00000000000000479616 -15.99999999999999822364 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000000941469 0.00000000000001068035 -42.50000000000000000000
+CurvePt 1 4.60000000000000319744 0.00000000000000479616 -15.99999999999999822364
+AddCurve
+Curve 00000034 1 2 00000017 00000013
+CCtrl 0 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000001829648 -4.59999999999998898659 -42.50000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000000941469 0.00000000000000994061 -42.50000000000000000000
+CurvePt 0 4.58139257961925139284 -0.41333041432943135041 -42.49999999999999289457
+CurvePt 0 4.55745278147393140245 -0.62419880217412482271 -42.49999999999999289457
+CurvePt 0 4.52320469471625319358 -0.83703004109585565917 -42.50000000000000000000
+CurvePt 0 4.47829642479663991850 -1.05112374706964217808 -42.50000000000000710543
+CurvePt 0 4.42243520766035658198 -1.26572778828868948153 -42.50000000000000710543
+CurvePt 0 4.35539545467173017101 -1.48004406469027438575 -42.50000000000000000000
+CurvePt 0 4.27702618488719288337 -1.69323566398460512161 -42.50000000000000000000
+CurvePt 0 4.18725758368107925378 -1.90443533046028323774 -42.50000000000000000000
+CurvePt 0 4.08610643141687557289 -2.11275512805760623536 -42.49999999999999289457
+CurvePt 0 3.97368016323819928104 -2.31729712386808728297 -42.50000000000000000000
+CurvePt 0 3.85017935160581004084 -2.51716486557164653703 -42.49999999999999289457
+CurvePt 0 3.71589844650147194116 -2.71147537980487873810 -42.50000000000000710543
+CurvePt 0 3.57122466284429318506 -2.89937138143645212196 -42.50000000000000000000
+CurvePt 0 3.41663496823849666129 -3.08003335920408449766 -42.50000000000000710543
+CurvePt 0 3.25269119345813439992 -3.25269119345811130728 -42.50000000000000000000
+CurvePt 0 3.08003335920410847848 -3.41663496823847312456 -42.50000000000000710543
+CurvePt 0 2.89937138143647699096 -3.57122466284427142469 -42.50000000000000000000
+CurvePt 0 2.71147537980490493936 -3.71589844650145062488 -42.50000000000000710543
+CurvePt 0 2.51716486557167318239 -3.85017935160578961273 -42.49999999999999289457
+CurvePt 0 2.31729712386811392832 -3.97368016323817929702 -42.50000000000000000000
+CurvePt 0 2.11275512805763332480 -4.08610643141685692115 -42.49999999999999289457
+CurvePt 0 1.90443533046031121536 -4.18725758368106060203 -42.50000000000000000000
+CurvePt 0 1.69323566398463332128 -4.27702618488717511980 -42.50000000000000000000
+CurvePt 0 1.48004406469030258542 -4.35539545467171418380 -42.50000000000000000000
+CurvePt 0 1.26572778828871790324 -4.42243520766034237113 -42.50000000000000710543
+CurvePt 0 1.05112374706967126592 -4.47829642479662393129 -42.50000000000000710543
+CurvePt 0 0.83703004109588496906 -4.52320469471623987090 -42.50000000000000000000
+CurvePt 0 0.62419880217415424362 -4.55745278147391896795 -42.49999999999999289457
+CurvePt 0 0.41333041432946082683 -4.58139257961923984652 -42.49999999999999289457
+CurvePt 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+AddCurve
+Curve 00000035 1 1 00000018 00000017
+CCtrl 0 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+CurvePt 1 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+AddCurve
+Curve 00000036 1 2 00000018 00000014
+CCtrl 0 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999997832845 -4.60000000000000941469 -42.50000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000001965917 -4.59999999999999964473 -42.50000000000000000000
+CurvePt 0 -0.41333041432942158044 -4.58139257961924162288 -42.49999999999999289457
+CurvePt 0 -0.62419880217411494172 -4.55745278147392163248 -42.49999999999999289457
+CurvePt 0 -0.83703004109584566717 -4.52320469471624342361 -42.50000000000000000000
+CurvePt 0 -1.05112374706963240811 -4.47829642479662926036 -42.50000000000000710543
+CurvePt 0 -1.26572778828867948953 -4.42243520766034681202 -42.50000000000000710543
+CurvePt 0 -1.48004406469026394966 -4.35539545467172128923 -42.50000000000000000000
+CurvePt 0 -1.69323566398459535165 -4.27702618488718222522 -42.50000000000000000000
+CurvePt 0 -1.90443533046027302369 -4.18725758368106948382 -42.50000000000000000000
+CurvePt 0 -2.11275512805759646540 -4.08610643141686669111 -42.49999999999999289457
+CurvePt 0 -2.31729712386807706892 -3.97368016323818995517 -42.50000000000000000000
+CurvePt 0 -2.51716486557163632298 -3.85017935160580071496 -42.49999999999999289457
+CurvePt 0 -2.71147537980486896814 -3.71589844650146261529 -42.50000000000000710543
+CurvePt 0 -2.89937138143644235200 -3.57122466284428430328 -42.50000000000000000000
+CurvePt 0 -3.08003335920407472770 -3.41663496823848644723 -42.50000000000000710543
+CurvePt 0 -3.25269119345810064914 -3.25269119345812596222 -42.50000000000000000000
+CurvePt 0 -3.41663496823846335460 -3.08003335920410004078 -42.50000000000000710543
+CurvePt 0 -3.57122466284426165473 -2.89937138143646766508 -42.50000000000000000000
+CurvePt 0 -3.71589844650144041083 -2.71147537980489561349 -42.50000000000000710543
+CurvePt 0 -3.85017935160577984277 -2.51716486557166385651 -42.49999999999999289457
+CurvePt 0 -3.97368016323816952706 -2.31729712386810460245 -42.50000000000000000000
+CurvePt 0 -4.08610643141684715118 -2.11275512805762444302 -42.49999999999999289457
+CurvePt 0 -4.18725758368105083207 -1.90443533046030166744 -42.50000000000000000000
+CurvePt 0 -4.27702618488716534983 -1.69323566398462421745 -42.50000000000000000000
+CurvePt 0 -4.35539545467170441384 -1.48004406469029325955 -42.50000000000000000000
+CurvePt 0 -4.42243520766033171299 -1.26572778828870879941 -42.50000000000000710543
+CurvePt 0 -4.47829642479661504950 -1.05112374706966216209 -42.50000000000000710543
+CurvePt 0 -4.52320469471623010094 -0.83703004109587586523 -42.50000000000000000000
+CurvePt 0 -4.55745278147390830981 -0.62419880217414513979 -42.49999999999999289457
+CurvePt 0 -4.58139257961923007656 -0.41333041432945172300 -42.49999999999999289457
+CurvePt 1 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000
+AddCurve
+Curve 00000037 1 1 00000019 00000018
+CCtrl 0 -4.59999999999998987477 -0.00000000000001068035 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999999609201 -0.00000000000000479616 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999998987477 -0.00000000000001068035 -42.50000000000000000000
+CurvePt 1 -4.59999999999999609201 -0.00000000000000479616 -16.00000000000000000000
+AddCurve
+Curve 00000038 1 2 00000019 00000015
+CCtrl 0 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.60000000000000053291 4.59999999999998809841 -42.50000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999998987477 -0.00000000000001050395 -42.50000000000000000000
+CurvePt 0 -4.58139257961923274109 0.41333041432943079529 -42.49999999999999289457
+CurvePt 0 -4.55745278147391186252 0.62419880217412426759 -42.49999999999999289457
+CurvePt 0 -4.52320469471623365365 0.83703004109585521508 -42.50000000000000000000
+CurvePt 0 -4.47829642479662037857 1.05112374706964173399 -42.50000000000000710543
+CurvePt 0 -4.42243520766033793024 1.26572778828868881540 -42.50000000000000710543
+CurvePt 0 -4.35539545467171151927 1.48004406469027327553 -42.50000000000000000000
+CurvePt 0 -4.27702618488717334344 1.69323566398460445548 -42.50000000000000000000
+CurvePt 0 -4.18725758368105971385 1.90443533046028279365 -42.50000000000000000000
+CurvePt 0 -4.08610643141685692115 2.11275512805760579127 -42.49999999999999289457
+CurvePt 0 -3.97368016323818018520 2.31729712386808639479 -42.50000000000000000000
+CurvePt 0 -3.85017935160579138909 2.51716486557164609295 -42.49999999999999289457
+CurvePt 0 -3.71589844650145328941 2.71147537980487829401 -42.50000000000000710543
+CurvePt 0 -3.57122466284427542149 2.89937138143645167787 -42.50000000000000000000
+CurvePt 0 -3.41663496823847756545 3.08003335920408405357 -42.50000000000000710543
+CurvePt 0 -3.25269119345811708044 3.25269119345811086319 -42.50000000000000000000
+CurvePt 0 -3.08003335920409071491 3.41663496823847268047 -42.50000000000000710543
+CurvePt 0 -2.89937138143645878330 3.57122466284427142469 -42.50000000000000000000
+CurvePt 0 -2.71147537980488628762 3.71589844650145018079 -42.50000000000000710543
+CurvePt 0 -2.51716486557165453064 3.85017935160578961273 -42.49999999999999289457
+CurvePt 0 -2.31729712386809483249 3.97368016323817929702 -42.50000000000000000000
+CurvePt 0 -2.11275512805761511714 4.08610643141685692115 -42.49999999999999289457
+CurvePt 0 -1.90443533046029278566 4.18725758368106060203 -42.50000000000000000000
+CurvePt 0 -1.69323566398461511362 4.27702618488717511980 -42.50000000000000000000
+CurvePt 0 -1.48004406469028415572 4.35539545467171418380 -42.50000000000000000000
+CurvePt 0 -1.26572778828869991763 4.42243520766034237113 -42.50000000000000710543
+CurvePt 0 -1.05112374706965305826 4.47829642479662393129 -42.50000000000000710543
+CurvePt 0 -0.83703004109586653936 4.52320469471623987090 -42.50000000000000000000
+CurvePt 0 -0.62419880217413592494 4.55745278147391896795 -42.49999999999999289457
+CurvePt 0 -0.41333041432944261917 4.58139257961923984652 -42.49999999999999289457
+CurvePt 1 -0.00000000000000134872 4.59999999999999964473 -42.50000000000000000000
+AddCurve
+Curve 00000039 1 1 0000001a 0000001d
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000
+AddCurve
+Curve 0000003a 1 2 0000001a 00000016
+CCtrl 0 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.59999999999999875655 4.60000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.59999999999999964473 -16.00000000000000000000
+CurvePt 0 0.41333041432944106486 4.58139257961924162288 -15.99999999999999822364
+CurvePt 0 0.62419880217413437062 4.55745278147392074430 -16.00000000000000000000
+CurvePt 0 0.83703004109586531811 4.52320469471624253543 -16.00000000000000000000
+CurvePt 0 1.05112374706965194804 4.47829642479662837218 -16.00000000000000000000
+CurvePt 0 1.26572778828869880741 4.42243520766034592384 -16.00000000000000000000
+CurvePt 0 1.48004406469028326754 4.35539545467171862470 -15.99999999999999822364
+CurvePt 0 1.69323566398461444749 4.27702618488718044887 -16.00000000000000000000
+CurvePt 0 1.90443533046029234157 4.18725758368106681928 -16.00000000000000000000
+CurvePt 0 2.11275512805761556123 4.08610643141686402657 -15.99999999999999822364
+CurvePt 0 2.31729712386809616476 3.97368016323818640245 -15.99999999999999822364
+CurvePt 0 2.51716486557165541882 3.85017935160579716225 -15.99999999999999822364
+CurvePt 0 2.71147537980488761988 3.71589844650145906257 -16.00000000000000000000
+CurvePt 0 2.89937138143646055966 3.57122466284428075056 -16.00000000000000000000
+CurvePt 0 3.08003335920409204718 3.41663496823848245043 -16.00000000000000000000
+CurvePt 0 3.25269119345811930089 3.25269119345812107724 -16.00000000000000000000
+CurvePt 0 3.41663496823848067407 3.08003335920409471171 -16.00000000000000000000
+CurvePt 0 3.57122466284427941829 2.89937138143646322419 -15.99999999999999822364
+CurvePt 0 3.71589844650145817440 2.71147537980489028442 -16.00000000000000000000
+CurvePt 0 3.85017935160579671816 2.51716486557165897153 -15.99999999999999822364
+CurvePt 0 3.97368016323818640245 2.31729712386809927338 -15.99999999999999644729
+CurvePt 0 4.08610643141686402657 2.11275512805761911395 -15.99999999999999822364
+CurvePt 0 4.18725758368106770746 1.90443533046029589428 -15.99999999999999644729
+CurvePt 0 4.27702618488718133705 1.69323566398461800020 -15.99999999999999822364
+CurvePt 0 4.35539545467171951287 1.48004406469028726434 -15.99999999999999822364
+CurvePt 0 4.42243520766034681202 1.26572778828870280421 -16.00000000000000000000
+CurvePt 0 4.47829642479663014853 1.05112374706965594484 -16.00000000000000000000
+CurvePt 0 4.52320469471624431179 0.83703004109586953696 -15.99999999999999822364
+CurvePt 0 4.55745278147392340884 0.62419880217413870049 -15.99999999999999822364
+CurvePt 0 4.58139257961924339924 0.41333041432944533922 -15.99999999999999644729
+CurvePt 1 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364
+AddCurve
+Curve 0000003b 1 1 0000001b 0000001a
+CCtrl 0 4.60000000000000319744 0.00000000000000479616 -15.99999999999999822364 Weight 1.00000000000000000000
+CCtrl 1 4.20000000000000017764 0.00000000000000115463 0.00000000000000093259 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000000319744 0.00000000000000479616 -15.99999999999999822364
+CurvePt 1 4.20000000000000017764 0.00000000000000115463 0.00000000000000093259
+AddCurve
+Curve 0000003c 1 2 0000001b 00000017
+CCtrl 0 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364 Weight 1.00000000000000000000
+CCtrl 1 4.60000000000000675016 -4.59999999999999431566 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.60000000000000319744 0.00000000000000405643 -15.99999999999999822364
+CurvePt 0 4.58139257961924428741 -0.41333041432943717908 -15.99999999999999644729
+CurvePt 0 4.55745278147392429702 -0.62419880217413059587 -15.99999999999999822364
+CurvePt 0 4.52320469471624519997 -0.83703004109586143233 -15.99999999999999822364
+CurvePt 0 4.47829642479663103671 -1.05112374706964772919 -16.00000000000000000000
+CurvePt 0 4.42243520766034858838 -1.26572778828869503265 -16.00000000000000000000
+CurvePt 0 4.35539545467172217741 -1.48004406469027971482 -15.99999999999999822364
+CurvePt 0 4.27702618488718400158 -1.69323566398461045068 -15.99999999999999822364
+CurvePt 0 4.18725758368107037199 -1.90443533046028856681 -15.99999999999999644729
+CurvePt 0 4.08610643141686757929 -2.11275512805761112034 -15.99999999999999822364
+CurvePt 0 3.97368016323818995517 -2.31729712386809172386 -15.99999999999999644729
+CurvePt 0 3.85017935160580071496 -2.51716486557165142202 -15.99999999999999822364
+CurvePt 0 3.71589844650146261529 -2.71147537980488362308 -15.99999999999999822364
+CurvePt 0 3.57122466284428385919 -2.89937138143645611876 -15.99999999999999822364
+CurvePt 0 3.41663496823848600314 -3.08003335920408849447 -16.00000000000000000000
+CurvePt 0 3.25269119345812462996 -3.25269119345811530408 -16.00000000000000000000
+CurvePt 0 3.08003335920409826443 -3.41663496823847667727 -16.00000000000000000000
+CurvePt 0 2.89937138143646677690 -3.57122466284427542149 -16.00000000000000000000
+CurvePt 0 2.71147537980489383713 -3.71589844650145373350 -15.99999999999999822364
+CurvePt 0 2.51716486557166208016 -3.85017935160579227727 -15.99999999999999822364
+CurvePt 0 2.31729712386810282609 -3.97368016323818240565 -15.99999999999999822364
+CurvePt 0 2.11275512805762266666 -4.08610643141685958568 -15.99999999999999822364
+CurvePt 0 1.90443533046029989109 -4.18725758368106326657 -16.00000000000000000000
+CurvePt 0 1.69323566398462199700 -4.27702618488717778433 -16.00000000000000000000
+CurvePt 0 1.48004406469029103910 -4.35539545467171684834 -15.99999999999999822364
+CurvePt 0 1.26572778828870635692 -4.42243520766034325931 -16.00000000000000000000
+CurvePt 0 1.05112374706965971960 -4.47829642479662659582 -16.00000000000000000000
+CurvePt 0 0.83703004109587320070 -4.52320469471624075908 -16.00000000000000000000
+CurvePt 0 0.62419880217414247525 -4.55745278147391985613 -16.00000000000000000000
+CurvePt 0 0.41333041432944916949 -4.58139257961924073470 -15.99999999999999822364
+CurvePt 1 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+AddCurve
+Curve 0000003d 1 1 0000001c 0000001b
+CCtrl 0 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+CurvePt 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+AddCurve
+Curve 0000003e 1 2 0000001c 00000018
+CCtrl 0 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.59999999999999076294 -4.60000000000000319744 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000789081 -4.59999999999999964473 -16.00000000000000000000
+CurvePt 0 -0.41333041432943334881 -4.58139257961924162288 -15.99999999999999822364
+CurvePt 0 -0.62419880217412693213 -4.55745278147392074430 -16.00000000000000000000
+CurvePt 0 -0.83703004109585765757 -4.52320469471624253543 -16.00000000000000000000
+CurvePt 0 -1.05112374706964395443 -4.47829642479662837218 -16.00000000000000000000
+CurvePt 0 -1.26572778828869103585 -4.42243520766034592384 -16.00000000000000000000
+CurvePt 0 -1.48004406469027571802 -4.35539545467171862470 -15.99999999999999822364
+CurvePt 0 -1.69323566398460645388 -4.27702618488718044887 -16.00000000000000000000
+CurvePt 0 -1.90443533046028479205 -4.18725758368106681928 -16.00000000000000000000
+CurvePt 0 -2.11275512805760756763 -4.08610643141686402657 -15.99999999999999822364
+CurvePt 0 -2.31729712386808817115 -3.97368016323818640245 -15.99999999999999822364
+CurvePt 0 -2.51716486557164786930 -3.85017935160579716225 -15.99999999999999822364
+CurvePt 0 -2.71147537980488007037 -3.71589844650145906257 -16.00000000000000000000
+CurvePt 0 -2.89937138143645301014 -3.57122466284428075056 -16.00000000000000000000
+CurvePt 0 -3.08003335920408494175 -3.41663496823848245043 -16.00000000000000000000
+CurvePt 0 -3.25269119345811130728 -3.25269119345812152133 -16.00000000000000000000
+CurvePt 0 -3.41663496823847356865 -3.08003335920409471171 -16.00000000000000000000
+CurvePt 0 -3.57122466284427142469 -2.89937138143646322419 -16.00000000000000000000
+CurvePt 0 -3.71589844650145018079 -2.71147537980489072851 -16.00000000000000000000
+CurvePt 0 -3.85017935160578961273 -2.51716486557165897153 -15.99999999999999822364
+CurvePt 0 -3.97368016323817796476 -2.31729712386809927338 -15.99999999999999822364
+CurvePt 0 -4.08610643141685692115 -2.11275512805761911395 -15.99999999999999822364
+CurvePt 0 -4.18725758368105882568 -1.90443533046029633837 -16.00000000000000000000
+CurvePt 0 -4.27702618488717334344 -1.69323566398461844429 -16.00000000000000000000
+CurvePt 0 -4.35539545467171240745 -1.48004406469028793047 -15.99999999999999822364
+CurvePt 0 -4.42243520766033881841 -1.26572778828870324830 -16.00000000000000000000
+CurvePt 0 -4.47829642479662215493 -1.05112374706965638893 -16.00000000000000000000
+CurvePt 0 -4.52320469471623809454 -0.83703004109586998105 -16.00000000000000000000
+CurvePt 0 -4.55745278147391541523 -0.62419880217413914458 -16.00000000000000000000
+CurvePt 0 -4.58139257961923718199 -0.41333041432944583882 -15.99999999999999822364
+CurvePt 1 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000
+AddCurve
+Curve 0000003f 1 1 0000001d 0000001c
+CCtrl 0 -4.59999999999999609201 -0.00000000000000479616 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.20000000000000017764 -0.00000000000000115463 -0.00000000000000093259 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999999609201 -0.00000000000000479616 -16.00000000000000000000
+CurvePt 1 -4.20000000000000017764 -0.00000000000000115463 -0.00000000000000093259
+AddCurve
+Curve 00000040 1 2 0000001d 00000019
+CCtrl 0 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.60000000000000053291 4.59999999999999431566 -16.00000000000000000000 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.59999999999999609201 -0.00000000000000461976 -16.00000000000000000000
+CurvePt 0 -4.58139257961923807017 0.41333041432943667948 -15.99999999999999822364
+CurvePt 0 -4.55745278147391719159 0.62419880217413015178 -16.00000000000000000000
+CurvePt 0 -4.52320469471623898272 0.83703004109586098824 -16.00000000000000000000
+CurvePt 0 -4.47829642479662570764 1.05112374706964728510 -16.00000000000000000000
+CurvePt 0 -4.42243520766034237113 1.26572778828869458856 -16.00000000000000000000
+CurvePt 0 -4.35539545467171596016 1.48004406469027927074 -15.99999999999999822364
+CurvePt 0 -4.27702618488717689615 1.69323566398461000659 -16.00000000000000000000
+CurvePt 0 -4.18725758368106326657 1.90443533046028790068 -16.00000000000000000000
+CurvePt 0 -4.08610643141686047386 2.11275512805761112034 -15.99999999999999822364
+CurvePt 0 -3.97368016323818329383 2.31729712386809127977 -15.99999999999999822364
+CurvePt 0 -3.85017935160579449771 2.51716486557165142202 -15.99999999999999822364
+CurvePt 0 -3.71589844650145639804 2.71147537980488362308 -16.00000000000000000000
+CurvePt 0 -3.57122466284427808603 2.89937138143645611876 -16.00000000000000000000
+CurvePt 0 -3.41663496823847978590 3.08003335920408805038 -16.00000000000000000000
+CurvePt 0 -3.25269119345811841271 3.25269119345811530408 -16.00000000000000000000
+CurvePt 0 -3.08003335920409160309 3.41663496823847667727 -16.00000000000000000000
+CurvePt 0 -2.89937138143646055966 3.57122466284427497740 -16.00000000000000000000
+CurvePt 0 -2.71147537980488761988 3.71589844650145373350 -16.00000000000000000000
+CurvePt 0 -2.51716486557165541882 3.85017935160579227727 -15.99999999999999822364
+CurvePt 0 -2.31729712386809616476 3.97368016323818240565 -15.99999999999999822364
+CurvePt 0 -2.11275512805761600532 4.08610643141685958568 -15.99999999999999822364
+CurvePt 0 -1.90443533046029322975 4.18725758368106237839 -16.00000000000000000000
+CurvePt 0 -1.69323566398461533566 4.27702618488717778433 -16.00000000000000000000
+CurvePt 0 -1.48004406469028459981 4.35539545467171684834 -15.99999999999999822364
+CurvePt 0 -1.26572778828870013967 4.42243520766034325931 -16.00000000000000000000
+CurvePt 0 -1.05112374706965328031 4.47829642479662659582 -16.00000000000000000000
+CurvePt 0 -0.83703004109586676140 4.52320469471624075908 -16.00000000000000000000
+CurvePt 0 -0.62419880217413603596 4.55745278147391985613 -16.00000000000000000000
+CurvePt 0 -0.41333041432944261917 4.58139257961924073470 -15.99999999999999822364
+CurvePt 1 -0.00000000000000134872 4.59999999999999964473 -16.00000000000000000000
+AddCurve
+Curve 00000041 1 1 0000001e 00000021
+CCtrl 0 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000
+AddCurve
+Curve 00000042 1 2 0000001e 0000001a
+CCtrl 0 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.19999999999999928946 4.20000000000000017764 0.00000000000000093259 Weight 0.70710678118654757274
+CCtrl 2 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.20000000000000017764 0.00000000000000000000
+CurvePt 0 0.37738863917035925244 4.18301061617408986848 0.00000000000000008380
+CurvePt 0 0.76424482013100758504 4.12988254734961302006 0.00000000000000016970
+CurvePt 0 0.95972168210707342606 4.08887934437952971223 0.00000000000000021310
+CurvePt 0 1.15566450235055118156 4.03787562438553226940 0.00000000000000025661
+CurvePt 0 1.35134458080417152459 3.97666541513504689931 0.00000000000000030006
+CurvePt 0 1.54599778015986522028 3.90511086446220767598 0.00000000000000034328
+CurvePt 0 1.73883225824635356815 3.82314822857836400516 0.00000000000000038610
+CurvePt 0 1.92903729083521380261 3.73079282868496164838 0.00000000000000042833
+CurvePt 0 2.11579302614043518460 3.62814275773921224300 0.00000000000000046980
+CurvePt 0 2.29828096421759831003 3.51538114711833538095 0.00000000000000051032
+CurvePt 0 2.47569491199576674489 3.39277684245785193795 0.00000000000000054971
+CurvePt 0 2.64725213087676802814 3.26068338781434086115 0.00000000000000058781
+CurvePt 0 2.81220437144721424616 3.11953627534817812261 0.00000000000000062443
+CurvePt 0 2.96984848098349951684 2.96984848098350040502 0.00000000000000065944
+CurvePt 0 3.11953627534817679035 2.81220437144721469025 0.00000000000000069268
+CurvePt 0 3.26068338781434086115 2.64725213087676847223 0.00000000000000072402
+CurvePt 0 3.39277684245785193795 2.47569491199576718898 0.00000000000000075335
+CurvePt 0 3.51538114711833493686 2.29828096421759919821 0.00000000000000078057
+CurvePt 0 3.62814275773921224300 2.11579302614043562869 0.00000000000000080561
+CurvePt 0 3.73079282868496120429 1.92903729083521446874 0.00000000000000082840
+CurvePt 0 3.82314822857836400516 1.73883225824635467838 0.00000000000000084891
+CurvePt 0 3.90511086446220767598 1.54599778015986610846 0.00000000000000086711
+CurvePt 0 3.97666541513504689931 1.35134458080417219072 0.00000000000000088300
+CurvePt 0 4.03787562438553226940 1.15566450235055184770 0.00000000000000089659
+CurvePt 0 4.08887934437952971223 0.95972168210707409219 0.00000000000000090791
+CurvePt 0 4.12988254734961213188 0.76424482013100825117 0.00000000000000091702
+CurvePt 0 4.18301061617408986848 0.37738863917036002960 0.00000000000000092881
+CurvePt 1 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259
+AddCurve
+Curve 00000043 1 1 0000001f 0000001e
+CCtrl 0 4.20000000000000017764 0.00000000000000115463 0.00000000000000093259 Weight 1.00000000000000000000
+CCtrl 1 4.20000000000000017764 0.00000000000000093259 1.00000000000000088818 Weight 1.00000000000000000000
+CurvePt 1 4.20000000000000017764 0.00000000000000115463 0.00000000000000093259
+CurvePt 1 4.20000000000000017764 0.00000000000000093259 1.00000000000000088818
+AddCurve
+Curve 00000044 1 2 0000001f 0000001b
+CCtrl 0 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259 Weight 1.00000000000000000000
+CCtrl 1 4.20000000000000017764 -4.19999999999999840128 0.00000000000000093259 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.20000000000000017764 0.00000000000000047922 0.00000000000000093259
+CurvePt 0 4.18301061617408986848 -0.37738863917035891937 0.00000000000000092881
+CurvePt 0 4.12988254734961302006 -0.76424482013100714095 0.00000000000000091702
+CurvePt 0 4.08887934437952971223 -0.95972168210707309299 0.00000000000000090791
+CurvePt 0 4.03787562438553226940 -1.15566450235055073748 0.00000000000000089659
+CurvePt 0 3.97666541513504689931 -1.35134458080417152459 0.00000000000000088300
+CurvePt 0 3.90511086446220767598 -1.54599778015986499824 0.00000000000000086711
+CurvePt 0 3.82314822857836400516 -1.73883225824635334611 0.00000000000000084891
+CurvePt 0 3.73079282868496164838 -1.92903729083521335852 0.00000000000000082840
+CurvePt 0 3.62814275773921224300 -2.11579302614043474051 0.00000000000000080561
+CurvePt 0 3.51538114711833538095 -2.29828096421759786594 0.00000000000000078057
+CurvePt 0 3.39277684245785193795 -2.47569491199576585672 0.00000000000000075335
+CurvePt 0 3.26068338781434086115 -2.64725213087676758406 0.00000000000000072402
+CurvePt 0 3.11953627534817812261 -2.81220437144721380207 0.00000000000000069268
+CurvePt 0 2.96984848098350040502 -2.96984848098349907275 0.00000000000000065944
+CurvePt 0 2.81220437144721469025 -3.11953627534817679035 0.00000000000000062443
+CurvePt 0 2.64725213087676891632 -3.26068338781434041707 0.00000000000000058781
+CurvePt 0 2.47569491199576763307 -3.39277684245785149386 0.00000000000000054971
+CurvePt 0 2.29828096421759919821 -3.51538114711833493686 0.00000000000000051032
+CurvePt 0 2.11579302614043562869 -3.62814275773921224300 0.00000000000000046980
+CurvePt 0 1.92903729083521469079 -3.73079282868496120429 0.00000000000000042833
+CurvePt 0 1.73883225824635490042 -3.82314822857836356107 0.00000000000000038610
+CurvePt 0 1.54599778015986633051 -3.90511086446220767598 0.00000000000000034328
+CurvePt 0 1.35134458080417241277 -3.97666541513504689931 0.00000000000000030006
+CurvePt 0 1.15566450235055206974 -4.03787562438553226940 0.00000000000000025661
+CurvePt 0 0.95972168210707442526 -4.08887934437952971223 0.00000000000000021310
+CurvePt 0 0.76424482013100847322 -4.12988254734961213188 0.00000000000000016970
+CurvePt 0 0.37738863917036025164 -4.18301061617408986848 0.00000000000000008380
+CurvePt 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+AddCurve
+Curve 00000045 1 1 00000020 0000001f
+CCtrl 0 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+CurvePt 1 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000
+AddCurve
+Curve 00000046 1 2 00000020 0000001c
+CCtrl 0 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.19999999999999840128 -4.20000000000000017764 -0.00000000000000093259 Weight 0.70710678118654757274
+CCtrl 2 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000073640 -4.20000000000000017764 0.00000000000000000000
+CurvePt 0 -0.37738863917035869733 -4.18301061617408986848 -0.00000000000000008380
+CurvePt 0 -0.76424482013100691891 -4.12988254734961302006 -0.00000000000000016970
+CurvePt 0 -0.95972168210707287095 -4.08887934437952971223 -0.00000000000000021310
+CurvePt 0 -1.15566450235055073748 -4.03787562438553226940 -0.00000000000000025661
+CurvePt 0 -1.35134458080417130255 -3.97666541513504689931 -0.00000000000000030006
+CurvePt 0 -1.54599778015986477619 -3.90511086446220767598 -0.00000000000000034328
+CurvePt 0 -1.73883225824635312406 -3.82314822857836400516 -0.00000000000000038610
+CurvePt 0 -1.92903729083521313648 -3.73079282868496164838 -0.00000000000000042833
+CurvePt 0 -2.11579302614043474051 -3.62814275773921224300 -0.00000000000000046980
+CurvePt 0 -2.29828096421759786594 -3.51538114711833538095 -0.00000000000000051032
+CurvePt 0 -2.47569491199576585672 -3.39277684245785193795 -0.00000000000000054971
+CurvePt 0 -2.64725213087676758406 -3.26068338781434086115 -0.00000000000000058781
+CurvePt 0 -2.81220437144721380207 -3.11953627534817812261 -0.00000000000000062443
+CurvePt 0 -2.96984848098349907275 -2.96984848098350084911 -0.00000000000000065944
+CurvePt 0 -3.11953627534817679035 -2.81220437144721557843 -0.00000000000000069268
+CurvePt 0 -3.26068338781433997298 -2.64725213087676891632 -0.00000000000000072402
+CurvePt 0 -3.39277684245785104977 -2.47569491199576763307 -0.00000000000000075335
+CurvePt 0 -3.51538114711833493686 -2.29828096421759919821 -0.00000000000000078057
+CurvePt 0 -3.62814275773921224300 -2.11579302614043607278 -0.00000000000000080561
+CurvePt 0 -3.73079282868496120429 -1.92903729083521469079 -0.00000000000000082840
+CurvePt 0 -3.82314822857836356107 -1.73883225824635490042 -0.00000000000000084891
+CurvePt 0 -3.90511086446220767598 -1.54599778015986655255 -0.00000000000000086711
+CurvePt 0 -3.97666541513504689931 -1.35134458080417263481 -0.00000000000000088300
+CurvePt 0 -4.03787562438553226940 -1.15566450235055229179 -0.00000000000000089659
+CurvePt 0 -4.08887934437952971223 -0.95972168210707453628 -0.00000000000000090791
+CurvePt 0 -4.12988254734961213188 -0.76424482013100869526 -0.00000000000000091702
+CurvePt 0 -4.18301061617408986848 -0.37738863917036047368 -0.00000000000000092881
+CurvePt 1 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259
+AddCurve
+Curve 00000047 1 1 00000021 00000020
+CCtrl 0 -4.20000000000000017764 -0.00000000000000115463 -0.00000000000000093259 Weight 1.00000000000000000000
+CCtrl 1 -4.20000000000000017764 -0.00000000000000093259 0.99999999999999911182 Weight 1.00000000000000000000
+CurvePt 1 -4.20000000000000017764 -0.00000000000000115463 -0.00000000000000093259
+CurvePt 1 -4.20000000000000017764 -0.00000000000000093259 0.99999999999999911182
+AddCurve
+Curve 00000048 1 2 00000021 0000001d
+CCtrl 0 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259 Weight 1.00000000000000000000
+CCtrl 1 -4.20000000000000017764 4.19999999999999840128 -0.00000000000000093259 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.20000000000000017764 -0.00000000000000099357 -0.00000000000000093259
+CurvePt 0 -4.18301061617408986848 0.37738863917035847528 -0.00000000000000092881
+CurvePt 0 -4.12988254734961302006 0.76424482013100669686 -0.00000000000000091702
+CurvePt 0 -4.08887934437952971223 0.95972168210707264890 -0.00000000000000090791
+CurvePt 0 -4.03787562438553226940 1.15566450235055029339 -0.00000000000000089659
+CurvePt 0 -3.97666541513504689931 1.35134458080417108050 -0.00000000000000088300
+CurvePt 0 -3.90511086446220767598 1.54599778015986455415 -0.00000000000000086711
+CurvePt 0 -3.82314822857836400516 1.73883225824635312406 -0.00000000000000084891
+CurvePt 0 -3.73079282868496164838 1.92903729083521313648 -0.00000000000000082840
+CurvePt 0 -3.62814275773921224300 2.11579302614043474051 -0.00000000000000080561
+CurvePt 0 -3.51538114711833538095 2.29828096421759742185 -0.00000000000000078057
+CurvePt 0 -3.39277684245785193795 2.47569491199576541263 -0.00000000000000075335
+CurvePt 0 -3.26068338781434130524 2.64725213087676758406 -0.00000000000000072402
+CurvePt 0 -3.11953627534817856670 2.81220437144721380207 -0.00000000000000069268
+CurvePt 0 -2.96984848098350084911 2.96984848098349907275 -0.00000000000000065944
+CurvePt 0 -2.81220437144721557843 3.11953627534817679035 -0.00000000000000062443
+CurvePt 0 -2.64725213087676891632 3.26068338781433997298 -0.00000000000000058781
+CurvePt 0 -2.47569491199576763307 3.39277684245785104977 -0.00000000000000054971
+CurvePt 0 -2.29828096421759919821 3.51538114711833449277 -0.00000000000000051032
+CurvePt 0 -2.11579302614043607278 3.62814275773921135482 -0.00000000000000046980
+CurvePt 0 -1.92903729083521491283 3.73079282868496120429 -0.00000000000000042833
+CurvePt 0 -1.73883225824635512247 3.82314822857836356107 -0.00000000000000038610
+CurvePt 0 -1.54599778015986655255 3.90511086446220767598 -0.00000000000000034328
+CurvePt 0 -1.35134458080417263481 3.97666541513504689931 -0.00000000000000030006
+CurvePt 0 -1.15566450235055251383 4.03787562438553226940 -0.00000000000000025661
+CurvePt 0 -0.95972168210707475833 4.08887934437952971223 -0.00000000000000021310
+CurvePt 0 -0.76424482013100902833 4.12988254734961213188 -0.00000000000000016970
+CurvePt 0 -0.37738863917036069573 4.18301061617408986848 -0.00000000000000008380
+CurvePt 1 -0.00000000000000125075 4.20000000000000017764 -0.00000000000000000000
+AddCurve
+Curve 00000049 1 1 00000022 00000022
+CCtrl 0 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000
+AddCurve
+Curve 0000004a 1 2 00000022 0000001e
+CCtrl 0 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 4.20000000000000017764 4.19999999999999928946 1.00000000000000088818 Weight 0.70710678118654757274
+CCtrl 2 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 4.20000000000000017764 1.00000000000000000000
+CurvePt 0 0.37738863917035930795 4.18301061617408986848 1.00000000000000000000
+CurvePt 0 0.76424482013100769606 4.12988254734961213188 1.00000000000000022204
+CurvePt 0 0.95972168210707364810 4.08887934437952971223 1.00000000000000022204
+CurvePt 0 1.15566450235055140361 4.03787562438553226940 1.00000000000000022204
+CurvePt 0 1.35134458080417174664 3.97666541513504689931 1.00000000000000022204
+CurvePt 0 1.54599778015986544233 3.90511086446220767598 1.00000000000000044409
+CurvePt 0 1.73883225824635401224 3.82314822857836400516 1.00000000000000044409
+CurvePt 0 1.92903729083521424670 3.73079282868496120429 1.00000000000000022204
+CurvePt 0 2.11579302614043562869 3.62814275773921224300 1.00000000000000044409
+CurvePt 0 2.29828096421759875412 3.51538114711833493686 1.00000000000000022204
+CurvePt 0 2.47569491199576718898 3.39277684245785193795 1.00000000000000044409
+CurvePt 0 2.64725213087676847223 3.26068338781434086115 1.00000000000000066613
+CurvePt 0 2.81220437144721469025 3.11953627534817679035 1.00000000000000088818
+CurvePt 0 2.96984848098350040502 2.96984848098349951684 1.00000000000000066613
+CurvePt 0 3.11953627534817812261 2.81220437144721424616 1.00000000000000088818
+CurvePt 0 3.26068338781434086115 2.64725213087676802814 1.00000000000000066613
+CurvePt 0 3.39277684245785193795 2.47569491199576674489 1.00000000000000066613
+CurvePt 0 3.51538114711833538095 2.29828096421759831003 1.00000000000000066613
+CurvePt 0 3.62814275773921224300 2.11579302614043518460 1.00000000000000066613
+CurvePt 0 3.73079282868496164838 1.92903729083521424670 1.00000000000000066613
+CurvePt 0 3.82314822857836400516 1.73883225824635401224 1.00000000000000088818
+CurvePt 0 3.90511086446220767598 1.54599778015986588642 1.00000000000000066613
+CurvePt 0 3.97666541513504689931 1.35134458080417196868 1.00000000000000088818
+CurvePt 0 4.03787562438553226940 1.15566450235055162565 1.00000000000000088818
+CurvePt 0 4.08887934437952971223 0.95972168210707375913 1.00000000000000088818
+CurvePt 0 4.12988254734961302006 0.76424482013100802913 1.00000000000000088818
+CurvePt 0 4.18301061617408986848 0.37738863917035975204 1.00000000000000088818
+CurvePt 1 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818
+AddCurve
+Curve 0000004b 1 1 00000022 00000022
+CCtrl 0 4.20000000000000017764 0.00000000000000093259 1.00000000000000088818 Weight 1.00000000000000000000
+CCtrl 1 2.70000000000000017764 0.00000000000000059952 1.00000000000000066613 Weight 1.00000000000000000000
+CurvePt 1 4.20000000000000017764 0.00000000000000093259 1.00000000000000088818
+CurvePt 1 2.70000000000000017764 0.00000000000000059952 1.00000000000000066613
+AddCurve
+Curve 0000004c 1 2 00000022 0000001f
+CCtrl 0 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818 Weight 1.00000000000000000000
+CCtrl 1 4.19999999999999928946 -4.19999999999999928946 1.00000000000000088818 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 4.20000000000000017764 0.00000000000000025718 1.00000000000000088818
+CurvePt 0 4.18301061617408986848 -0.37738863917035925244 1.00000000000000088818
+CurvePt 0 4.12988254734961213188 -0.76424482013100758504 1.00000000000000088818
+CurvePt 0 4.08887934437952971223 -0.95972168210707331504 1.00000000000000088818
+CurvePt 0 4.03787562438553226940 -1.15566450235055118156 1.00000000000000088818
+CurvePt 0 3.97666541513504689931 -1.35134458080417152459 1.00000000000000088818
+CurvePt 0 3.90511086446220767598 -1.54599778015986522028 1.00000000000000066613
+CurvePt 0 3.82314822857836400516 -1.73883225824635356815 1.00000000000000088818
+CurvePt 0 3.73079282868496120429 -1.92903729083521358056 1.00000000000000066613
+CurvePt 0 3.62814275773921224300 -2.11579302614043518460 1.00000000000000066613
+CurvePt 0 3.51538114711833493686 -2.29828096421759831003 1.00000000000000066613
+CurvePt 0 3.39277684245785193795 -2.47569491199576674489 1.00000000000000066613
+CurvePt 0 3.26068338781434086115 -2.64725213087676802814 1.00000000000000066613
+CurvePt 0 3.11953627534817679035 -2.81220437144721424616 1.00000000000000088818
+CurvePt 0 2.96984848098349951684 -2.96984848098349951684 1.00000000000000066613
+CurvePt 0 2.81220437144721424616 -3.11953627534817679035 1.00000000000000066613
+CurvePt 0 2.64725213087676802814 -3.26068338781434086115 1.00000000000000066613
+CurvePt 0 2.47569491199576674489 -3.39277684245785193795 1.00000000000000044409
+CurvePt 0 2.29828096421759875412 -3.51538114711833493686 1.00000000000000044409
+CurvePt 0 2.11579302614043562869 -3.62814275773921224300 1.00000000000000022204
+CurvePt 0 1.92903729083521424670 -3.73079282868496120429 1.00000000000000022204
+CurvePt 0 1.73883225824635401224 -3.82314822857836400516 1.00000000000000022204
+CurvePt 0 1.54599778015986588642 -3.90511086446220767598 1.00000000000000044409
+CurvePt 0 1.35134458080417196868 -3.97666541513504689931 1.00000000000000022204
+CurvePt 0 1.15566450235055162565 -4.03787562438553226940 1.00000000000000022204
+CurvePt 0 0.95972168210707375913 -4.08887934437952971223 1.00000000000000022204
+CurvePt 0 0.76424482013100802913 -4.12988254734961213188 1.00000000000000022204
+CurvePt 0 0.37738863917035980755 -4.18301061617408986848 1.00000000000000000000
+CurvePt 1 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000
+AddCurve
+Curve 0000004d 1 1 00000022 00000022
+CCtrl 0 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000
+CurvePt 1 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000
+AddCurve
+Curve 0000004e 1 2 00000022 00000020
+CCtrl 0 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -4.19999999999999840128 -4.20000000000000017764 0.99999999999999911182 Weight 0.70710678118654757274
+CCtrl 2 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000029231 -4.20000000000000017764 1.00000000000000000000
+CurvePt 0 -0.37738863917035908591 -4.18301061617408986848 0.99999999999999977796
+CurvePt 0 -0.76424482013100736300 -4.12988254734961302006 0.99999999999999988898
+CurvePt 0 -0.95972168210707320402 -4.08887934437952971223 0.99999999999999988898
+CurvePt 0 -1.15566450235055095952 -4.03787562438553226940 0.99999999999999988898
+CurvePt 0 -1.35134458080417152459 -3.97666541513504689931 0.99999999999999966693
+CurvePt 0 -1.54599778015986499824 -3.90511086446220767598 0.99999999999999966693
+CurvePt 0 -1.73883225824635334611 -3.82314822857836400516 0.99999999999999955591
+CurvePt 0 -1.92903729083521335852 -3.73079282868496164838 0.99999999999999955591
+CurvePt 0 -2.11579302614043474051 -3.62814275773921224300 0.99999999999999944489
+CurvePt 0 -2.29828096421759786594 -3.51538114711833538095 0.99999999999999955591
+CurvePt 0 -2.47569491199576585672 -3.39277684245785193795 0.99999999999999955591
+CurvePt 0 -2.64725213087676758406 -3.26068338781434086115 0.99999999999999933387
+CurvePt 0 -2.81220437144721380207 -3.11953627534817812261 0.99999999999999955591
+CurvePt 0 -2.96984848098349907275 -2.96984848098350040502 0.99999999999999944489
+CurvePt 0 -3.11953627534817679035 -2.81220437144721469025 0.99999999999999955591
+CurvePt 0 -3.26068338781434041707 -2.64725213087676891632 0.99999999999999933387
+CurvePt 0 -3.39277684245785149386 -2.47569491199576763307 0.99999999999999933387
+CurvePt 0 -3.51538114711833493686 -2.29828096421759919821 0.99999999999999911182
+CurvePt 0 -3.62814275773921224300 -2.11579302614043562869 0.99999999999999911182
+CurvePt 0 -3.73079282868496120429 -1.92903729083521469079 0.99999999999999922284
+CurvePt 0 -3.82314822857836356107 -1.73883225824635490042 0.99999999999999911182
+CurvePt 0 -3.90511086446220767598 -1.54599778015986633051 0.99999999999999922284
+CurvePt 0 -3.97666541513504689931 -1.35134458080417241277 0.99999999999999922284
+CurvePt 0 -4.03787562438553226940 -1.15566450235055206974 0.99999999999999922284
+CurvePt 0 -4.08887934437952971223 -0.95972168210707442526 0.99999999999999911182
+CurvePt 0 -4.12988254734961213188 -0.76424482013100847322 0.99999999999999922284
+CurvePt 0 -4.18301061617408986848 -0.37738863917036025164 0.99999999999999900080
+CurvePt 1 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182
+AddCurve
+Curve 0000004f 1 1 00000022 00000022
+CCtrl 0 -4.20000000000000017764 -0.00000000000000093259 0.99999999999999911182 Weight 1.00000000000000000000
+CCtrl 1 -2.70000000000000062172 -0.00000000000000059952 0.99999999999999944489 Weight 1.00000000000000000000
+CurvePt 1 -4.20000000000000017764 -0.00000000000000093259 0.99999999999999911182
+CurvePt 1 -2.70000000000000062172 -0.00000000000000059952 0.99999999999999944489
+AddCurve
+Curve 00000050 1 2 00000022 00000021
+CCtrl 0 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182 Weight 1.00000000000000000000
+CCtrl 1 -4.20000000000000017764 4.19999999999999840128 0.99999999999999911182 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000125075 4.20000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -4.20000000000000017764 -0.00000000000000077153 0.99999999999999911182
+CurvePt 0 -4.18301061617408986848 0.37738863917035869733 0.99999999999999900080
+CurvePt 0 -4.12988254734961302006 0.76424482013100691891 0.99999999999999922284
+CurvePt 0 -4.08887934437952971223 0.95972168210707287095 0.99999999999999911182
+CurvePt 0 -4.03787562438553226940 1.15566450235055029339 0.99999999999999922284
+CurvePt 0 -3.97666541513504689931 1.35134458080417130255 0.99999999999999922284
+CurvePt 0 -3.90511086446220767598 1.54599778015986477619 0.99999999999999922284
+CurvePt 0 -3.82314822857836400516 1.73883225824635312406 0.99999999999999911182
+CurvePt 0 -3.73079282868496164838 1.92903729083521313648 0.99999999999999922284
+CurvePt 0 -3.62814275773921224300 2.11579302614043474051 0.99999999999999911182
+CurvePt 0 -3.51538114711833538095 2.29828096421759786594 0.99999999999999911182
+CurvePt 0 -3.39277684245785193795 2.47569491199576585672 0.99999999999999933387
+CurvePt 0 -3.26068338781434130524 2.64725213087676758406 0.99999999999999933387
+CurvePt 0 -3.11953627534817856670 2.81220437144721380207 0.99999999999999944489
+CurvePt 0 -2.96984848098350084911 2.96984848098349907275 0.99999999999999944489
+CurvePt 0 -2.81220437144721557843 3.11953627534817679035 0.99999999999999955591
+CurvePt 0 -2.64725213087676891632 3.26068338781433997298 0.99999999999999933387
+CurvePt 0 -2.47569491199576763307 3.39277684245785104977 0.99999999999999955591
+CurvePt 0 -2.29828096421759919821 3.51538114711833493686 0.99999999999999944489
+CurvePt 0 -2.11579302614043607278 3.62814275773921224300 0.99999999999999955591
+CurvePt 0 -1.92903729083521491283 3.73079282868496120429 0.99999999999999955591
+CurvePt 0 -1.73883225824635512247 3.82314822857836356107 0.99999999999999955591
+CurvePt 0 -1.54599778015986655255 3.90511086446220767598 0.99999999999999966693
+CurvePt 0 -1.35134458080417263481 3.97666541513504689931 0.99999999999999966693
+CurvePt 0 -1.15566450235055251383 4.03787562438553226940 0.99999999999999977796
+CurvePt 0 -0.95972168210707475833 4.08887934437952971223 0.99999999999999988898
+CurvePt 0 -0.76424482013100902833 4.12988254734961213188 0.99999999999999988898
+CurvePt 0 -0.37738863917036069573 4.18301061617408986848 0.99999999999999977796
+CurvePt 1 -0.00000000000000125075 4.20000000000000017764 1.00000000000000000000
+AddCurve
+Curve 00000051 1 1 00000023 00000026
+CCtrl 0 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 2.70000000000000017764 0.00000000000000000000
+AddCurve
+Curve 00000052 1 2 00000023 00000022
+CCtrl 0 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 2.70000000000000017764 2.69999999999999973355 1.00000000000000088818 Weight 0.70710678118654757274
+CCtrl 2 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613 Weight 1.00000000000000000000
+CurvePt 1 -0.00000000000000022204 2.70000000000000017764 1.00000000000000000000
+CurvePt 0 0.24260698232380237260 2.68907825325477212175 1.00000000000000000000
+CurvePt 0 0.49130024151279055866 2.65492449472475122718 1.00000000000000022204
+CurvePt 0 0.74292718008249736261 2.59577718710498484000 1.00000000000000022204
+CurvePt 0 0.99385571581705656197 2.51042841286856210914 1.00000000000000022204
+CurvePt 0 1.24009540125120909515 2.39836681844033261513 1.00000000000000022204
+CurvePt 0 1.47746633413988481820 2.25988788029035836402 1.00000000000000022204
+CurvePt 0 1.70180494127792258929 2.09615360645207671197 1.00000000000000044409
+CurvePt 0 1.90918830920367854631 1.90918830920367854631 1.00000000000000066613
+CurvePt 0 2.09615360645207671197 1.70180494127792236725 1.00000000000000066613
+CurvePt 0 2.25988788029035836402 1.47746633413988459615 1.00000000000000066613
+CurvePt 0 2.39836681844033261513 1.24009540125120909515 1.00000000000000066613
+CurvePt 0 2.51042841286856210914 0.99385571581705667299 1.00000000000000066613
+CurvePt 0 2.59577718710498528409 0.74292718008249747363 1.00000000000000066613
+CurvePt 0 2.65492449472475122718 0.49130024151279078071 1.00000000000000066613
+CurvePt 0 2.68907825325477212175 0.24260698232380267791 1.00000000000000066613
+CurvePt 1 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613
+AddCurve
+Curve 00000053 1 1 00000024 00000023
+CCtrl 0 2.70000000000000017764 0.00000000000000059952 1.00000000000000066613 Weight 1.00000000000000000000
+CCtrl 1 2.70000000000000017764 0.00000000000000082157 0.00000000000000059952 Weight 1.00000000000000000000
+CurvePt 1 2.70000000000000017764 0.00000000000000059952 1.00000000000000066613
+CurvePt 1 2.70000000000000017764 0.00000000000000082157 0.00000000000000059952
+AddCurve
+Curve 00000054 1 2 00000024 00000022
+CCtrl 0 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613 Weight 1.00000000000000000000
+CCtrl 1 2.70000000000000017764 -2.69999999999999973355 1.00000000000000088818 Weight 0.70710678118654757274
+CCtrl 2 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 2.70000000000000017764 0.00000000000000016533 1.00000000000000066613
+CurvePt 0 2.68907825325477212175 -0.24260698232380237260 1.00000000000000066613
+CurvePt 0 2.65492449472475122718 -0.49130024151279055866 1.00000000000000066613
+CurvePt 0 2.59577718710498528409 -0.74292718008249725159 1.00000000000000066613
+CurvePt 0 2.51042841286856210914 -0.99385571581705633992 1.00000000000000066613
+CurvePt 0 2.39836681844033261513 -1.24009540125120909515 1.00000000000000066613
+CurvePt 0 2.25988788029035836402 -1.47746633413988459615 1.00000000000000066613
+CurvePt 0 2.09615360645207671197 -1.70180494127792236725 1.00000000000000066613
+CurvePt 0 1.90918830920367854631 -1.90918830920367854631 1.00000000000000066613
+CurvePt 0 1.70180494127792258929 -2.09615360645207671197 1.00000000000000044409
+CurvePt 0 1.47746633413988481820 -2.25988788029035836402 1.00000000000000022204
+CurvePt 0 1.24009540125120909515 -2.39836681844033261513 1.00000000000000022204
+CurvePt 0 0.99385571581705667299 -2.51042841286856210914 1.00000000000000044409
+CurvePt 0 0.74292718008249758466 -2.59577718710498484000 1.00000000000000022204
+CurvePt 0 0.49130024151279078071 -2.65492449472475122718 1.00000000000000022204
+CurvePt 0 0.24260698232380267791 -2.68907825325477212175 1.00000000000000000000
+CurvePt 1 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000
+AddCurve
+Curve 00000055 1 1 00000025 00000024
+CCtrl 0 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000
+CurvePt 1 0.00000000000000055270 -2.70000000000000017764 0.00000000000000000000
+AddCurve
+Curve 00000056 1 2 00000025 00000022
+CCtrl 0 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CCtrl 1 -2.70000000000000017764 -2.70000000000000017764 0.99999999999999955591 Weight 0.70710678118654757274
+CCtrl 2 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489 Weight 1.00000000000000000000
+CurvePt 1 0.00000000000000010861 -2.70000000000000017764 1.00000000000000000000
+CurvePt 0 -0.24260698232380248363 -2.68907825325477212175 0.99999999999999988898
+CurvePt 0 -0.49130024151279066968 -2.65492449472475122718 0.99999999999999988898
+CurvePt 0 -0.74292718008249736261 -2.59577718710498528409 1.00000000000000000000
+CurvePt 0 -0.99385571581705656197 -2.51042841286856210914 0.99999999999999988898
+CurvePt 0 -1.24009540125120931719 -2.39836681844033261513 0.99999999999999966693
+CurvePt 0 -1.47746633413988504024 -2.25988788029035836402 0.99999999999999955591
+CurvePt 0 -1.70180494127792258929 -2.09615360645207671197 0.99999999999999977796
+CurvePt 0 -1.90918830920367854631 -1.90918830920367876836 0.99999999999999977796
+CurvePt 0 -2.09615360645207671197 -1.70180494127792281134 0.99999999999999955591
+CurvePt 0 -2.25988788029035880811 -1.47746633413988504024 0.99999999999999944489
+CurvePt 0 -2.39836681844033305921 -1.24009540125120931719 0.99999999999999944489
+CurvePt 0 -2.51042841286856255323 -0.99385571581705689503 0.99999999999999955591
+CurvePt 0 -2.59577718710498572818 -0.74292718008249780670 0.99999999999999966693
+CurvePt 0 -2.65492449472475167127 -0.49130024151279116928 0.99999999999999944489
+CurvePt 0 -2.68907825325477256584 -0.24260698232380303874 0.99999999999999944489
+CurvePt 1 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489
+AddCurve
+Curve 00000057 1 1 00000026 00000025
+CCtrl 0 -2.70000000000000062172 -0.00000000000000059952 0.99999999999999944489 Weight 1.00000000000000000000
+CCtrl 1 -2.70000000000000017764 -0.00000000000000082157 -0.00000000000000059952 Weight 1.00000000000000000000
+CurvePt 1 -2.70000000000000062172 -0.00000000000000059952 0.99999999999999944489
+CurvePt 1 -2.70000000000000017764 -0.00000000000000082157 -0.00000000000000059952
+AddCurve
+Curve 00000058 1 2 00000026 00000022
+CCtrl 0 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489 Weight 1.00000000000000000000
+CCtrl 1 -2.70000000000000106581 2.69999999999999928946 0.99999999999999955591 Weight 0.70710678118654757274
+CCtrl 2 -0.00000000000000088335 2.70000000000000017764 1.00000000000000000000 Weight 1.00000000000000000000
+CurvePt 1 -2.70000000000000062172 -0.00000000000000049598 0.99999999999999944489
+CurvePt 0 -2.68907825325477256584 0.24260698232380203954 0.99999999999999944489
+CurvePt 0 -2.65492449472475167127 0.49130024151279017008 0.99999999999999944489
+CurvePt 0 -2.59577718710498572818 0.74292718008249691852 0.99999999999999966693
+CurvePt 0 -2.51042841286856255323 0.99385571581705600686 0.99999999999999955591
+CurvePt 0 -2.39836681844033350330 1.24009540125120842902 0.99999999999999944489
+CurvePt 0 -2.25988788029035925220 1.47746633413988437411 0.99999999999999944489
+CurvePt 0 -2.09615360645207715606 1.70180494127792214520 0.99999999999999955591
+CurvePt 0 -1.90918830920367943449 1.90918830920367810222 0.99999999999999977796
+CurvePt 0 -1.70180494127792347747 2.09615360645207626789 0.99999999999999955591
+CurvePt 0 -1.47746633413988570638 2.25988788029035791993 0.99999999999999966693
+CurvePt 0 -1.24009540125120998333 2.39836681844033261513 0.99999999999999966693
+CurvePt 0 -0.99385571581705745015 2.51042841286856166505 0.99999999999999988898
+CurvePt 0 -0.74292718008249836181 2.59577718710498484000 1.00000000000000000000
+CurvePt 0 -0.49130024151279161337 2.65492449472475078309 0.99999999999999988898
+CurvePt 0 -0.24260698232380345507 2.68907825325477212175 0.99999999999999988898
+CurvePt 1 -0.00000000000000088335 2.70000000000000017764 1.00000000000000000000
+AddCurve

--- a/issues/462/LICENSE.txt
+++ b/issues/462/LICENSE.txt
@@ -1,0 +1,2 @@
+This file is provided by rpavlik under CC0
+


### PR DESCRIPTION
Hopefully this is how you want it contributed - let me know if you want something different.

I am the author of this file and contribute it under CC0 (or another license if you prefer) - do what you want with it.

In a bad commit (between the introduction and fix of 462), running `solvespace-cli export-view --output test.png --view isometric  462-active-group-is-lathe-triggered-double-free.slvs` triggers it.